### PR TITLE
Allow merge with empty defaultConfig in istio Operator

### DIFF
--- a/operator/api/v1alpha1/istio_merge.go
+++ b/operator/api/v1alpha1/istio_merge.go
@@ -19,6 +19,9 @@ func (i *Istio) MergeInto(op istioOperator.IstioOperator) (istioOperator.IstioOp
 		return op, err
 	}
 
+	if c.DefaultConfig == nil {
+		c.DefaultConfig = &meshv1alpha1.ProxyConfig{}
+	}
 	// Since the gateway topology is not part of the default configuration, and we do not explicitly set it in the
 	// chart, it could be nil.
 	if c.DefaultConfig.GatewayTopology != nil {

--- a/operator/api/v1alpha1/istio_merge_test.go
+++ b/operator/api/v1alpha1/istio_merge_test.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -118,8 +117,6 @@ func TestIstioMergeInto(t *testing.T) {
 
 		// when
 		out, err := istioCR.MergeInto(iop)
-		fmt.Println(out)
-		fmt.Println(iop)
 
 		// then
 		require.NoError(t, err)

--- a/operator/api/v1alpha1/istio_merge_test.go
+++ b/operator/api/v1alpha1/istio_merge_test.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -96,7 +97,35 @@ func TestIstioMergeInto(t *testing.T) {
 			GetStructValue().Fields["gatewayTopology"].GetStructValue().Fields["numTrustedProxies"].GetNumberValue())
 
 	})
+	t.Run("Should set numTrustedProxies on IstioOperator to 5 when there is no defaultConfig in meshConfig", func(t *testing.T) {
+		// given
+		m := &v1alpha1.MeshConfig{
+			EnableTracing: true,
+		}
+		meshConfig, err := convert(m)
+		if err != nil {
+			t.Error(err)
+		}
 
+		iop := istioOperator.IstioOperator{
+			Spec: &operatorv1alpha1.IstioOperatorSpec{
+				MeshConfig: meshConfig,
+			},
+		}
+		numProxies := 5
+
+		istioCR := Istio{Spec: IstioSpec{Config: Config{NumTrustedProxies: &numProxies}}}
+
+		// when
+		out, err := istioCR.MergeInto(iop)
+		fmt.Println(out)
+		fmt.Println(iop)
+
+		// then
+		require.NoError(t, err)
+		require.Equal(t, float64(5), out.Spec.MeshConfig.Fields["defaultConfig"].
+			GetStructValue().Fields["gatewayTopology"].GetStructValue().Fields["numTrustedProxies"].GetNumberValue())
+	})
 }
 
 func convert(a *v1alpha1.MeshConfig) (*structpb.Struct, error) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- do not throw panic when passing iop file without defaultConfig set


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->