### PR TITLE
Add support for pod status.phase field selector in fake client

### DIFF
--- a/operator/pkg/lib/sidecars/pods/get_test.go
+++ b/operator/pkg/lib/sidecars/pods/get_test.go
@@ -23,7 +23,11 @@ func createClientSet(t *testing.T, objects ...client.Object) client.Client {
 	err = v1.AddToScheme(scheme.Scheme)
 	require.NoError(t, err)
 
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objects...).Build()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(objects...).
+		WithIndex(&v1.Pod{}, "status.phase", helpers.FakePodStatusPhaseIndexer).
+		Build()
 
 	return fakeClient
 }

--- a/operator/pkg/lib/sidecars/test/helpers/fake_client_indexer.go
+++ b/operator/pkg/lib/sidecars/test/helpers/fake_client_indexer.go
@@ -1,0 +1,15 @@
+package helpers
+
+import (
+	"fmt"
+	"k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func FakePodStatusPhaseIndexer(object client.Object) []string {
+	p, ok := object.(*v1.Pod)
+	if !ok {
+		panic(fmt.Errorf("indexer function for type %T's status.phase field received object of type %T", v1.Pod{}, object))
+	}
+	return []string{string(p.Status.Phase)}
+}

--- a/operator/pkg/lib/sidecars/test/test_client.go
+++ b/operator/pkg/lib/sidecars/test/test_client.go
@@ -55,11 +55,15 @@ func newScenario() (*scenario, error) {
 	}
 
 	return &scenario{
-		Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-			helpers.FixNamespaceWith(noAnnotationNamespace, nil),
-			helpers.FixNamespaceWith(sidecarEnabledNamespace, map[string]string{"istio-injection": "enabled"}),
-			helpers.FixNamespaceWith(sidecarDisabledNamespace, map[string]string{"istio-injection": "disabled"}),
-		).Build(),
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(
+				helpers.FixNamespaceWith(noAnnotationNamespace, nil),
+				helpers.FixNamespaceWith(sidecarEnabledNamespace, map[string]string{"istio-injection": "enabled"}),
+				helpers.FixNamespaceWith(sidecarDisabledNamespace, map[string]string{"istio-injection": "disabled"}),
+			).
+			WithIndex(&corev1.Pod{}, "status.phase", helpers.FakePodStatusPhaseIndexer).
+			Build(),
 		logger:                     logr.Discard(),
 		injectionNamespaceSelector: SidecarEnabled,
 	}, nil


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently some of the tests fail. We didn't have a test job configured for this repo when this was introduced, so we didn't see it.
The tests were failing since the update of sigs.k8s.io/controller-runtime from 0.13.1 to 0.14.0 (https://github.com/kyma-project/istio/pull/46).
The root cause why tests are failing is, that a support for indexes was introduced to the fake client (https://github.com/kubernetes-sigs/controller-runtime/pull/2025). Before the field selectors were just ignored. After adding the change in the fake client field selectors unknown to the fake client will cause an error.

Changes proposed in this pull request:

- Add the status.phase field selector fake to the fake client

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->