### PR TITLE
Label Istio namespace after installation

### DIFF
--- a/internal/reconciliations/istio/installation.go
+++ b/internal/reconciliations/istio/installation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/kyma-project/istio/operator/internal/resources"
+	"github.com/kyma-project/istio/operator/pkg/lib/label"
 
 	operatorv1alpha1 "github.com/kyma-project/istio/operator/api/v1alpha1"
 
@@ -76,6 +77,11 @@ func (i *Installation) Reconcile(ctx context.Context, client client.Client, isti
 		}
 
 		err = i.Client.Install(mergedIstioOperatorPath)
+		if err != nil {
+			return istioCR, err
+		}
+
+		err = label.AddIstioNamespaceLabel(ctx, client)
 		if err != nil {
 			return istioCR, err
 		}

--- a/internal/reconciliations/istio/installation_test.go
+++ b/internal/reconciliations/istio/installation_test.go
@@ -81,6 +81,7 @@ var _ = Describe("Installation reconciliation", func() {
 			},
 		}
 		istiod := createPod("istiod", gatherer.IstioNamespace, "discovery", istioVersion)
+		istioNamespace := createNamespace("istio-system")
 		mockClient := mockLibraryClient{}
 		installation := istio.Installation{
 			Client:         &mockClient,
@@ -88,7 +89,7 @@ var _ = Describe("Installation reconciliation", func() {
 			IstioImageBase: istioImageBase,
 		}
 		// when
-		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
+		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod, istioNamespace), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
 
 		// then
 		Expect(err).ShouldNot(HaveOccurred())
@@ -113,6 +114,7 @@ var _ = Describe("Installation reconciliation", func() {
 			},
 		}
 		istiod := createPod("istiod", gatherer.IstioNamespace, "discovery", "1.16.0")
+		istioNamespace := createNamespace("istio-system")
 		mockClient := mockLibraryClient{}
 		installation := istio.Installation{
 			Client:         &mockClient,
@@ -120,7 +122,7 @@ var _ = Describe("Installation reconciliation", func() {
 			IstioImageBase: istioImageBase,
 		}
 		// when
-		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
+		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod, istioNamespace), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
 
 		// then
 		Expect(err).Should(HaveOccurred())
@@ -146,6 +148,7 @@ var _ = Describe("Installation reconciliation", func() {
 			},
 		}
 		istiod := createPod("istiod", gatherer.IstioNamespace, "discovery", istioVersion)
+		istioNamespace := createNamespace("istio-system")
 		mockClient := mockLibraryClient{}
 		installation := istio.Installation{
 			Client:         &mockClient,
@@ -153,7 +156,7 @@ var _ = Describe("Installation reconciliation", func() {
 			IstioImageBase: istioImageBase,
 		}
 		// when
-		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
+		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod, istioNamespace), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
 
 		// then
 		Expect(err).ShouldNot(HaveOccurred())
@@ -179,6 +182,7 @@ var _ = Describe("Installation reconciliation", func() {
 			},
 		}
 		istiod := createPod("istiod", gatherer.IstioNamespace, "discovery", "1.17.0")
+		istioNamespace := createNamespace("istio-system")
 		mockClient := mockLibraryClient{}
 		installation := istio.Installation{
 			Client:         &mockClient,
@@ -186,7 +190,7 @@ var _ = Describe("Installation reconciliation", func() {
 			IstioImageBase: istioImageBase,
 		}
 		// when
-		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
+		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod, istioNamespace), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
 
 		// then
 		Expect(err).ShouldNot(HaveOccurred())
@@ -319,6 +323,7 @@ var _ = Describe("Installation reconciliation", func() {
 			},
 		}
 		istiod := createPod("istiod", gatherer.IstioNamespace, "discovery", istioVersion)
+		istioNamespace := createNamespace("istio-system")
 		mockClient := mockLibraryClient{}
 		installation := istio.Installation{
 			Client:         &mockClient,
@@ -326,7 +331,7 @@ var _ = Describe("Installation reconciliation", func() {
 			IstioImageBase: istioImageBase,
 		}
 		// when
-		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
+		returnedIstioCr, err := installation.Reconcile(context.TODO(), createFakeClient(&istioCr, istiod, istioNamespace), istioCr, defaultIstioOperatorPath, workingDir, resourceListPath)
 
 		// then
 		Expect(err).ShouldNot(HaveOccurred())
@@ -603,6 +608,14 @@ func createPod(name, namespace, containerName, imageVersion string) *corev1.Pod 
 					Image: "image:" + imageVersion,
 				},
 			},
+		},
+	}
+}
+
+func createNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
 		},
 	}
 }

--- a/pkg/lib/label/label.go
+++ b/pkg/lib/label/label.go
@@ -1,0 +1,56 @@
+package label
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	istioNamespace   = "istio-system"
+	wardenLabelKey   = "namespaces.warden.kyma-project.io/validate"
+	wardenLabelValue = "enabled"
+	disclaimerKey    = "istio.kyma-project.io/managed-by-istio-module-disclaimer"
+	disclaimerValue  = "DO NOT EDIT - This resource is managed by Kyma.\nAny modifications are discarded and the resource is reverted to the original state."
+)
+
+func AddIstioNamespaceLabel(ctx context.Context, kubeClient client.Client) error {
+	err := labelNamespace(ctx, kubeClient, istioNamespace, wardenLabelKey, wardenLabelValue)
+	if err != nil {
+		return err
+	}
+	err = labelNamespace(ctx, kubeClient, istioNamespace, disclaimerKey, disclaimerValue)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func labelNamespace(ctx context.Context, kubeClient client.Client, namespace, key, val string) error {
+	obj := &v1.Namespace{}
+	err := kubeClient.Get(ctx, types.NamespacedName{Name: namespace}, obj)
+	if err != nil {
+		return err
+	}
+	labels := addLabels(obj.Labels, key, val)
+	obj.SetLabels(labels)
+
+	patch := client.StrategicMergeFrom(obj.DeepCopy())
+	err = kubeClient.Patch(ctx, obj, patch)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addLabels(labels map[string]string, key, val string) map[string]string {
+	if len(labels) == 0 {
+		labels = map[string]string{}
+	}
+
+	labels[key] = val
+	return labels
+}


### PR DESCRIPTION
Part of #149 

Label `istio-system` namespace with warden config and also with info about being managed by Kyma. 