### PR TITLE
Add script for running istio integration tests on gardener

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,10 +263,19 @@ perf-test:
 	cd performance_tests && ./test.sh
 
 ########## Integration Tests ###########
+PULL_IMAGE_VERSION=PR-${PULL_NUMBER}
+POST_IMAGE_VERSION=v$(shell date '+%Y%m%d')-$(shell printf %.8s ${PULL_BASE_SHA})
+
 .PHONY: istio-integration-test
 istio-integration-test:
 	make install
+ifndef JOB_TYPE
 	make deploy
+else ifeq ($(JOB_TYPE), presubmit)
+	make deploy IMG=${PULL_IMAGE_VERSION}
+else ifeq ($(JOB_TYPE), postsubmit)
+	make deploy IMG=${POST_IMAGE_VERSION}
+endif
 	cd tests/integration && go test
 
 .PHONY: gardener-istio-integration-test

--- a/Makefile
+++ b/Makefile
@@ -272,9 +272,9 @@ istio-integration-test:
 ifndef JOB_TYPE
 	make deploy
 else ifeq ($(JOB_TYPE), presubmit)
-	make deploy IMG=${PULL_IMAGE_VERSION}
+	make deploy IMG=europe-docker.pkg.dev/kyma-project/dev/istio-manager:${PULL_IMAGE_VERSION}
 else ifeq ($(JOB_TYPE), postsubmit)
-	make deploy IMG=${POST_IMAGE_VERSION}
+	make deploy IMG=europe-docker.pkg.dev/kyma-project/prod/istio-manager:${POST_IMAGE_VERSION}
 endif
 	cd tests/integration && go test
 

--- a/Makefile
+++ b/Makefile
@@ -268,3 +268,7 @@ istio-integration-test:
 	make install
 	make deploy
 	cd tests/integration && go test
+
+.PHONY: gardener-istio-integration-test
+gardener-istio-integration-test:
+	./hack/ci/gardener-integration.sh

--- a/hack/ci/gardener-integration.sh
+++ b/hack/ci/gardener-integration.sh
@@ -3,7 +3,7 @@
 #
 ##Description: This script provisions a Gardener cluster with config specified in environmental variables and runs Istio module integration tests
 
-set -euxo pipefail
+set -euo pipefail
 
 function check_required_vars() {
   local requiredVarMissing=false

--- a/hack/ci/gardener-integration.sh
+++ b/hack/ci/gardener-integration.sh
@@ -80,4 +80,6 @@ kyma provision gardener ${GARDENER_PROVIDER} \
         --attempts 3 \
         --verbose
 
+./hack/ci/jobguard.sh
+
 make install deploy istio-integration-test

--- a/hack/ci/gardener-integration.sh
+++ b/hack/ci/gardener-integration.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+#
+##Description: This script provisions a Gardener cluster with config specified in environmental variables and runs Istio module integration tests
+
+set -euxo pipefail
+
+function check_required_vars() {
+  local requiredVarMissing=false
+  for var in "$@"; do
+    if [ -z "${!var}" ]; then
+      >&2 echo "Environment variable ${var} is required but not set"
+      requiredVarMissing=true
+    fi
+  done
+  if [ "${requiredVarMissing}" = true ] ; then
+    exit 2
+  fi
+}
+
+requiredVars=(
+    GARDENER_PROVIDER
+    GARDENER_REGION
+    GARDENER_ZONES
+    GARDENER_KYMA_PROW_KUBECONFIG
+    GARDENER_KYMA_PROW_PROJECT_NAME
+    GARDENER_KYMA_PROW_PROVIDER_SECRET_NAME
+    GARDENER_CLUSTER_VERSION
+    MACHINE_TYPE
+    DISK_SIZE
+    DISK_TYPE
+    SCALER_MAX
+    SCALER_MIN
+)
+
+check_required_vars "${requiredVars[@]}"
+
+function cleanup() {
+  kubectl annotate shoot "${CLUSTER_NAME}" confirmation.gardener.cloud/deletion=true \
+      --overwrite \
+      -n "garden-${GARDENER_KYMA_PROW_PROJECT_NAME}" \
+      --kubeconfig "${GARDENER_KYMA_PROW_KUBECONFIG}"
+
+  kubectl delete shoot "${CLUSTER_NAME}" \
+    --wait="false" \
+    --kubeconfig "${GARDENER_KYMA_PROW_KUBECONFIG}" \
+    -n "garden-${GARDENER_KYMA_PROW_PROJECT_NAME}"
+}
+
+# Cleanup on exit, be it successful or on fail
+trap cleanup EXIT INT
+
+# Install Kyma CLI in latest version
+echo "--> Install kyma CLI locally to /tmp/bin"
+curl -Lo kyma.tar.gz "https://github.com/kyma-project/cli/releases/latest/download/kyma_linux_x86_64.tar.gz" \
+&& tar -zxvf kyma.tar.gz && chmod +x kyma \
+&& rm -f kyma.tar.gz
+chmod +x kyma
+
+# Add pwd to path to be able to use Kyma binary
+export PATH="${PATH}:${PWD}"
+
+# Provision gardener cluster
+CLUSTER_NAME=ag-$(echo $RANDOM | md5sum | head -c 7)
+
+kyma version --client
+kyma provision gardener ${GARDENER_PROVIDER} \
+        --secret "${GARDENER_KYMA_PROW_PROVIDER_SECRET_NAME}" \
+        --name "${CLUSTER_NAME}" \
+        --project "${GARDENER_KYMA_PROW_PROJECT_NAME}" \
+        --credentials "${GARDENER_KYMA_PROW_KUBECONFIG}" \
+        --region "${GARDENER_REGION}" \
+        --zones "${GARDENER_ZONES}" \
+        --type "${MACHINE_TYPE}" \
+        --disk-size $DISK_SIZE \
+        --disk-type "${DISK_TYPE}" \
+        --scaler-max $SCALER_MAX \
+        --scaler-min $SCALER_MIN \
+        --kube-version="${GARDENER_CLUSTER_VERSION}" \
+        --attempts 3 \
+        --verbose
+
+make install deploy istio-integration-test

--- a/hack/ci/jobguard.sh
+++ b/hack/ci/jobguard.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-JOB_NAME_PATTERN=${JOB_NAME_PATTERN:-"(pre-main-kyma-components-.*)|(pre-main-kyma-tests-.*)|(pre-kyma-components-.*)|(pre-kyma-tests-.*)|(pull-.*-build)"}
+JOB_NAME_PATTERN=${JOB_NAME_PATTERN:-"(pull-.*-build)"}
 TIMEOUT=${JOBGUARD_TIMEOUT:-"15m"}
 
 if [[ "${BUILD_TYPE}" == "pr" ]]; then

--- a/hack/ci/jobguard.sh
+++ b/hack/ci/jobguard.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+JOB_NAME_PATTERN=${JOB_NAME_PATTERN:-"(pre-main-kyma-components-.*)|(pre-main-kyma-tests-.*)|(pre-kyma-components-.*)|(pre-kyma-tests-.*)|(pull-.*-build)"}
+TIMEOUT=${JOBGUARD_TIMEOUT:-"15m"}
+
+if [[ "${BUILD_TYPE}" == "pr" ]]; then
+    BASE_REF=${PULL_PULL_SHA}
+else
+    BASE_REF=${PULL_BASE_SHA}
+fi
+
+args=(
+  "-github-endpoint=http://ghproxy"
+  "-github-endpoint=https://api.github.com"
+  "-github-token-path=/etc/github/token"
+  "-fail-on-no-contexts=false"
+  "-timeout=$TIMEOUT"
+  "-org=$REPO_OWNER"
+  "-repo=$REPO_NAME"
+  "-base-ref=$BASE_REF"
+  "-expected-contexts-regexp=$JOB_NAME_PATTERN"
+)
+
+if [ -x "/prow-tools/jobguard" ]; then
+  /prow-tools/jobguard "${args[@]}"
+else
+  echo "Can not find jobguard in /prow-tools"
+  exit 1
+fi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Prepare make command and shell script for provisioning Gardener cluster and running Istio tests
- Script is ready for running on different cluster providers so it can be reused for autoscaler compliancy check later

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/test-infra/issues/7564