### PR TITLE
Increase memory and CPU limits for manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ else ifeq ($(JOB_TYPE), presubmit)
 else ifeq ($(JOB_TYPE), postsubmit)
 	make deploy IMG=europe-docker.pkg.dev/kyma-project/prod/istio-manager:${POST_IMAGE_VERSION}
 endif
-	cd tests/integration && EXPORT_RESULT=true go test
+	cd tests/integration && EXPORT_RESULT=true go test -timeout 25m
 
 .PHONY: gardener-istio-integration-test
 gardener-istio-integration-test:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -94,8 +94,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: 500m
-            memory: 128Mi
+            cpu: 1000m
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/tests/integration/features/istio/configuration.feature
+++ b/tests/integration/features/istio/configuration.feature
@@ -14,10 +14,12 @@ Feature: Configuration of Istio module
     And Application "test-app" is running in namespace "default"
     And Application "test-app" in namespace "default" has proxy with "requests" set to cpu - "30m" and memory - "190Mi"
     And Application "test-app" in namespace "default" has proxy with "limits" set to cpu - "700m" and memory - "700Mi"
+    And "Deployment" "test-app" in namespace "default" is ready
     And Template value "ProxyCPURequest" is set to "80m"
     And Template value "ProxyMemoryRequest" is set to "230Mi"
     And Template value "ProxyCPULimit" is set to "900m"
     And Template value "ProxyMemoryLimit" is set to "900Mi"
     When Istio CR "istio-sample" is updated in namespace "default"
-    Then Application "test-app" in namespace "default" has proxy with "requests" set to cpu - "80m" and memory - "230Mi"
+    Then "Deployment" "test-app" in namespace "default" is ready
+    And Application "test-app" in namespace "default" has proxy with "requests" set to cpu - "80m" and memory - "230Mi"
     And Application "test-app" in namespace "default" has proxy with "limits" set to cpu - "900m" and memory - "900Mi"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Increase limits for memory and CPU usage by Istio manager
- Increase test timeout
- Make proxy test more resilient by making sure deployment is ready before running restart

**Metrics**
- Based on Prometheus metrics:
![Screenshot 2023-06-06 at 12 26 20](https://github.com/kyma-project/istio/assets/103247439/d4f1b70d-3eed-4fcd-af12-4ffc7c0040d2)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/istio/issues/157