### PR TITLE
GitHub Actions cache build on main branch

### DIFF
--- a/.github/workflows/main-cache.yaml
+++ b/.github/workflows/main-cache.yaml
@@ -1,21 +1,15 @@
-name: Main
+name: Main cache
 
 on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - 'tests/performance/**'
-      - 'OWNERS'
-      - 'CODEOWNERS'
-      - 'sec-scanners-config.yaml'
-      - './github/dependabot.yml'
+    paths:
+      - 'go.mod'
 
 jobs:
 
-  run-unit-tests:
+  build-cache:
     name: Build cache
     description: Build cache on main so it can be reused in branches.
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,30 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'tests/performance/**'
+      - 'OWNERS'
+      - 'CODEOWNERS'
+      - 'sec-scanners-config.yaml'
+      - './github/dependabot.yml'
+permissions:
+  contents: read
+
+jobs:
+
+  run-unit-tests:
+    name: Build cache
+    description: Build cache on main so it can be reused in branches.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: build
+        run: make build

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,8 +12,6 @@ on:
       - 'CODEOWNERS'
       - 'sec-scanners-config.yaml'
       - './github/dependabot.yml'
-permissions:
-  contents: read
 
 jobs:
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,6 +10,7 @@ on:
       - 'OWNERS'
       - 'CODEOWNERS'
       - 'sec-scanners-config.yaml'
+      - './github/dependabot.yml'
     branches:
       - main
 permissions:

--- a/.github/workflows/verify-commit-pins.yaml
+++ b/.github/workflows/verify-commit-pins.yaml
@@ -1,4 +1,4 @@
-name: Verify that actions are SHA pinned
+name: Workflow validation
 
 on:
   pull_request:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
With our current config we create a cache with go dependencies for every PR. This caches can only be re-used in the same PR. That means the first workflows in a PR always have to download the dependencies, even when there are not changes to the dependencies.
To avoid that we can leverage the built-in usage of caches from the main branch. 

> Access restrictions provide cache isolation and security by creating a logical boundary between different branches or tags. Workflow runs can restore caches created in either the current branch or the default branch (usually main).  

[GitHub cache docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)


Changes proposed in this pull request:

- Add main workflow with a step to run go build and create the cache

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->