### PR TITLE
Change the size of headings

### DIFF
--- a/docs/user/01-10-istio-controller-parameters.md
+++ b/docs/user/01-10-istio-controller-parameters.md
@@ -2,11 +2,11 @@
 
 You can configure Istio Controller using various parameters. All options are listed in this document.
 
-### Reconciliation interval
+## Reconciliation interval
 
 By default, the Istio module is reconciled every 10 hours or whenever the custom resource is changed. You can adjust this interval by modifying the manager's parameters. For example, you can set the **-reconciliation-interval** parameter to `120s`.
 
-### All configuration parameters
+## All configuration parameters
 
 | Parameter                        | Description                                                                                                                                                                                                                                                                                                  | Default   |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|


### PR DESCRIPTION
Changes proposed in this pull request:

- Change the size of headings in the `Istio Controller parameters` document so that they can be displayed on the sidebar of the kyma-docs website