### PR TITLE
fix relative lins

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Istio is an open-source service mesh that provides a uniform way to manage, conn
 
 ## Istio module
 
-The Istio module allows you to add Istio Operator to the Kyma runtime. Within Istio Operator, Istio Controller is responsible for installing, uninstalling, and managing Istio. For more information, read the [Istio Controller documentation](./docs/user/00-10-overview-istio-controller.md).
+The Istio module allows you to add Istio Operator to the Kyma runtime. Within Istio Operator, Istio Controller is responsible for installing, uninstalling, and managing Istio. For more information, read the [Istio Controller documentation](/docs/user/00-10-overview-istio-controller.md).
 
 ## Install Istio Operator and Istio from the latest release
 
@@ -50,13 +50,13 @@ The Istio module allows you to add Istio Operator to the Kyma runtime. Within Is
    default   Ready
    ```
 
-For more installation options, visit [Install the Istio module](./docs/contributor/01-00-installation.md).
+For more installation options, visit [Install the Istio module](/docs/contributor/01-00-installation.md).
 
 ## Documentation
 
-To learn how to use the Istio module, read the documentation in the [user](./docs/user) directory.
+To learn how to use the Istio module, read the documentation in the [user](/docs/user) directory.
 
-If you are interested in the detailed documentation of the module's design and technical aspects, check the [contributor](./docs/contributor/) directory.
+If you are interested in the detailed documentation of the module's design and technical aspects, check the [contributor](/docs/contributor/) directory.
 
 ## Contributing
 

--- a/docs/contributor/04-10-technical-design.md
+++ b/docs/contributor/04-10-technical-design.md
@@ -2,10 +2,10 @@
 
 ## Kyma Istio Operator
 
-![Kyma IstioOperator Overview](./../assets/istio-operator-overview.svg)
+![Kyma IstioOperator Overview](/docs/assets/istio-operator-overview.svg)
 
 We want to keep the Kyma Istio operator as simple as possible. That's why we decided to start with one controller that consists of several self-contained components
-executing reconciliation logic. The controller uses [Istio CR](./04-20-xff-proposal.md) as a resource, which must be present in the `kyma-system` Namespace. The `ResourceQuota` resource ensures that there is only one Istio CR in a Kyma cluster.
+executing reconciliation logic. The controller uses [Istio CR](/docs/contributor/04-20-xff-proposal.md) as a resource, which must be present in the `kyma-system` Namespace. The `ResourceQuota` resource ensures that there is only one Istio CR in a Kyma cluster.
 
 ### Ownership of current resources in Kyma repository
 
@@ -64,7 +64,7 @@ Therefore, we have agreed that it is okay to block the reconciliation loop durin
 
 The following diagram shows the reconciliation process for installing, uninstalling, and canary upgrading (using revisions) Istio.
 
-![Istio Installation Reconciliation](../assets/istio-controller-reconciliation.svg)
+![Istio Installation Reconciliation](/docs/assets/istio-installation-reconciliation.svg)
 
 ### Istio upgrade version checking
 
@@ -79,7 +79,7 @@ and must work in isolation when assessing whether reconciliation is required, ap
 The execution of the reconciliation must be fast, and we must avoid many blocking calls. Long-running tasks must be executed asynchronously, and the status must be evaluated in the next reconciliation cycle.
 
  The following diagram shows the reconciliation loop of `IstioController`:
-![Reconciliation Loop Diagram](../assets/istio-controller-reconciliation-loop.svg)
+![Reconciliation Loop Diagram](/docs/assets/istio-controller-reconciliation-loop.svg)
 
 #### Interval
 
@@ -112,7 +112,7 @@ We need to make sure that each reconciliation component is completely independen
 The reason for this is that, for the sake of simplicity, we want to start with just one controller that handles all the logic to reconcile Istio. Since we have independent components, we can move them into new controllers if
 improving the performance of `IstioController` is necessary.
 
-![Controller Component Diagram](../assets/controller-component-diagram.svg)
+![Controller Component Diagram](/docs/assets/controller-component-diagram.svg)
 
 #### IstioController
 

--- a/docs/user/00-10-overview-istio-controller.md
+++ b/docs/user/00-10-overview-istio-controller.md
@@ -10,7 +10,7 @@ The version of Istio is dependent on the version of Istio Controller that you us
 
 ## Istio CR
 
-The `istios.operator.kyma-project.io` CustomResourceDefinition (CRD) describes the Istio CR that is used to manage the Istio installation. To learn more, read the [Istio CR documentation](../user/01-20-istio-custom-resource.md).
+The `istios.operator.kyma-project.io` CustomResourceDefinition (CRD) describes the Istio CR that is used to manage the Istio installation. To learn more, read the [Istio CR documentation](/docs/user/01-20-istio-custom-resource.md).
 
 ## Restart of workloads with enabled sidecar injection
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -6,10 +6,10 @@ Istio is an open-source service mesh that provides a uniform way to manage, conn
 
 ## Istio module
 
-The Istio module allows you to add Istio Operator to the Kyma runtime. Within Istio Operator, Istio Controller is responsible for installing, uninstalling, and managing Istio. For more information, read the [Istio Controller documentation](./00-10-overview-istio-controller.md).
+The Istio module allows you to add Istio Operator to the Kyma runtime. Within Istio Operator, Istio Controller is responsible for installing, uninstalling, and managing Istio. For more information, read the [Istio Controller documentation](/docs/user/00-10-overview-istio-controller.md).
 
 ## Documentation
 
-To learn how to use the Istio module, read the documentation in the [user](../user/) directory. 
+To learn how to use the Istio module, read the documentation in the [user](/docs/user/) directory. 
 
-If you are interested in the detailed documentation of the module's design and technical aspects, check the [contributor](../contributor/) directory.
+If you are interested in the detailed documentation of the module's design and technical aspects, check the [contributor](/docs/contributor/) directory.


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix relative links (all links should contain the /docs/... path so that they work on the docsify this microwebsite)
