### PR TITLE
Ignore controller runtime updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     commit-message:
       prefix: "gomod"
       include: "scope"
+    ignore:
+      - dependency-name: "sigs.k8s.io/controller-runtime"
     groups:
       k8s-dependencies:
         patterns:
@@ -36,6 +38,7 @@ updates:
       prefix: "gomod"
       include: "scope"
     ignore:
+      - dependency-name: "sigs.k8s.io/controller-runtime"
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- We need to keep the ctrl runtime version in sync with the version used by the Istio lib, that's why we should ignore it in Dependabot

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->