### PR TITLE
Add tcp keepalive to default mesh config

### DIFF
--- a/manifests/istio-operator-template-light.yaml
+++ b/manifests/istio-operator-template-light.yaml
@@ -125,6 +125,10 @@ spec:
             Any modifications are discarded and the resource is reverted to the original state.
   hub: europe-docker.pkg.dev/kyma-project/prod/external/istio
   meshConfig:
+    tcpKeepalive:
+      interval: 1s
+      probes: 9
+      time: 30s
     defaultConfig:
       holdApplicationUntilProxyStarts: true
       proxyMetadata:

--- a/manifests/istio-operator-template.yaml
+++ b/manifests/istio-operator-template.yaml
@@ -138,6 +138,10 @@ spec:
             Any modifications are discarded and the resource is reverted to the original state.
   hub: europe-docker.pkg.dev/kyma-project/prod/external/istio
   meshConfig:
+    tcpKeepalive:
+      interval: 1s
+      probes: 9
+      time: 30s
     defaultConfig:
       holdApplicationUntilProxyStarts: true
       proxyMetadata:


### PR DESCRIPTION
This adds tcp keep alive per default to the istio mesh config. 
This is necessary because:
- Apps usually use http keepalive to reuse sockets. Without istio configuration, the keep alive probes would only reach istio. Istio does not forward the application keep alive probes to the hyperscaler nat-gateway.
- It applies to all outbound connections, so istio destination rules are not the correct place for the configuration.
- All (AWS, Azure, GCP) hyperscaler nat-gateways and loadbalancers have an idle-timeout (4 Minutes on [Azure](https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-tcp-reset), 350s on [AWS](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout) and 10 minutes on [GCP](https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-networking)).
- Hyperscaler drop connections silently (without RST or FIN frames). [Azure has a way to change the configuration](https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-tcp-reset), the others do not.
- Without this configuration, application http clients will get connection reset when reusing idle sockets besides having an application keep-alive.

The timings were choosen with a sane default which should match all hyperscalers. Most technologies would even be more frequent, like nodejs for example with a [1s default](https://nodejs.org/api/http.html#new-agentoptions))