### PR TITLE
Add Istio operator metrics service

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- metrics_service.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,6 +62,9 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         image: controller:latest
         name: manager
+        ports:
+        - containerPort: 8080
+          name: http-metrics
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,9 +62,6 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         image: controller:latest
         name: manager
-        ports:
-        - containerPort: 8080
-          name: http-metrics
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/manager/metrics_service.yaml
+++ b/config/manager/metrics_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: operator-metrics
+  namespace: system
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/component: istio-operator.kyma-project.io
+    control-plane: controller-manager

--- a/main.go
+++ b/main.go
@@ -18,13 +18,15 @@ package main
 
 import (
 	"flag"
-	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"time"
+
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adds Istio operator metrics service so we can export operator metrics with runtime-monitoring-operator

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->