### PR TITLE
feat: consistent labels in istio module and its resources

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -10,7 +10,8 @@ namePrefix: istio-
 
 # Labels to add to all resources and selectors.
 commonLabels:
-  app.kubernetes.io/component: istio-operator.kyma-project.io
+  kyma-project.io/module: istio
+  app.kubernetes.io/version: 1.3.0-dev
 
 resources:
   - ../crd

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,12 +5,9 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/name: controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -5,12 +5,9 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernets.io/name: servicemonitor
-    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernets.io/name: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system
 spec:

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -2,12 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: metrics-reader
+    kyma-project.io/module: istio
+    app.kubernetes.io/name: metrics-reader
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: metrics-reader
 rules:
 - nonResourceURLs:

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -2,12 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/name: proxy-role
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: proxy-role
 rules:
 - apiGroups:

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -2,12 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/name: proxy-rolebinding
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -3,12 +3,9 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: service
-    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/name: controller-manager-metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system
 spec:

--- a/config/rbac/istio_editor_role.yaml
+++ b/config/rbac/istio_editor_role.yaml
@@ -3,12 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: istio-editor-role
+    app.kubernetes.io/name: istio-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: istio-editor-role
 rules:
 - apiGroups:

--- a/config/rbac/istio_viewer_role.yaml
+++ b/config/rbac/istio_viewer_role.yaml
@@ -3,12 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: istio-viewer-role
+    app.kubernetes.io/name: istio-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: istio-viewer-role
 rules:
 - apiGroups:

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -3,12 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: role
-    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/name: leader-election-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernets.io/managed-by: kustomize
   name: leader-election-role
 rules:
 - apiGroups:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -2,12 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/name: leader-election-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -2,12 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/name: manager-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,11 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/name: controller-manager
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: istio
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system


### PR DESCRIPTION
/kind feat
/area service-mesh
/hold

Based on the decision held in https://github.com/kyma-project/community/issues/864 adjusted labels for all resources:

* add common label kyma-project.io/module and app.kubernetes.io/version
* changed the purpose of a app.kubernetes.io/name label to reflect the resource name
* removed app.kubernetes.io/managed-by label because it is handled by external manager
* removed app.kubernetes.io/instance label as I think it also should be managed by external manager (TBD)
* removed app.kubernetes.io/created-by label as it's not listed in the standard labels proposal

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->
#548 