### PR TITLE
Change upgrade test to not merge manifest with old one

### DIFF
--- a/tests/integration/features/istio/production/upgrade-suite/istio_upgrade.feature
+++ b/tests/integration/features/istio/production/upgrade-suite/istio_upgrade.feature
@@ -1,4 +1,7 @@
+# Important: scenarios in this feature rely on the execution order
 Feature: Upgrade Istio
+  Scenario: Fail when there is operator manifest is not applicable
+    When Istio controller has been upgraded with "failing" manifest and should "fail"
 
   Scenario: Upgrade from latest release to current version
     Given "Istio CR" is not present on cluster
@@ -9,7 +12,7 @@ Feature: Upgrade Istio
     And Istio injection is "enabled" in namespace "default"
     And Application "test-app" is running in namespace "default"
     And Application pod "test-app" in namespace "default" has Istio proxy "present"
-    When Istio controller has been upgraded to the new version
+    When Istio controller has been upgraded with "generated" manifest and should "succeed"
     Then "Deployment" "istio-controller-manager" in namespace "kyma-system" is ready
     And Istio CR "istio-sample" in namespace "kyma-system" status update happened in the last 20 seconds
     And Istio CR "istio-sample" in namespace "kyma-system" has status "Ready"

--- a/tests/integration/manifests/fail-operator-manifest.yaml
+++ b/tests/integration/manifests/fail-operator-manifest.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: istio-operator.kyma-project.io
+    app.kubernetes.io/created-by: istio
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: istio
+    control-plane: controller-manager
+  name: istio-controller-manager
+  namespace: kyma-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        command:
+        - /manager
+        image: europe-docker.pkg.dev/kyma-project/prod/istio-manager:1.0.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: istio-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/tests/integration/scenario.go
+++ b/tests/integration/scenario.go
@@ -72,7 +72,7 @@ func upgradeInitScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^Istio injection is "([^"]*)" in namespace "([^"]*)"$`, steps.SetIstioInjection)
 	ctx.Step(`^Application "([^"]*)" is running in namespace "([^"]*)"$`, steps.CreateApplicationDeployment)
 	ctx.Step(`^Application pod "([^"]*)" in namespace "([^"]*)" has Istio proxy "([^"]*)"$`, steps.ApplicationPodShouldHaveIstioProxy)
-	ctx.Step(`^Istio controller has been upgraded to the new version$`, steps.DeployIstioOperatorFromLocalManifest)
+	ctx.Step(`^Istio controller has been upgraded with "([^"]*)" manifest and should "([^"]*)"$`, steps.DeployIstioOperator)
 	ctx.Step(`^Application "([^"]*)" in namespace "([^"]*)" has required version of proxy$`, steps.ApplicationPodShouldHaveIstioProxyInRequiredVersion)
 	ctx.Step(`^Container "([^"]*)" of "([^"]*)" "([^"]*)" in namespace "([^"]*)" has required version$`, steps.IstioResourceContainerHasRequiredVersion)
 }

--- a/tests/integration/steps/operator.go
+++ b/tests/integration/steps/operator.go
@@ -14,9 +14,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func DeployIstioOperatorFromLocalManifest(ctx context.Context) error {
+func DeployIstioOperator(ctx context.Context, manifestType, should string) error {
 	const manifestDirectory = "manifests"
-	const manifestFileName = "generated-operator-manifest.yaml"
+
+	var manifestFileName string
+	switch manifestType {
+	case "generated":
+		manifestFileName = "generated-operator-manifest.yaml"
+	case "failing":
+		manifestFileName = "fail-operator-manifest.yaml"
+	default:
+		return fmt.Errorf("unsupported manifest type: %s", manifestType)
+	}
+
+	expectSuccess := false
+	if should == "succeed" {
+		expectSuccess = true
+	}
+
 	k8sClient, err := testcontext.GetK8sClientFromContext(ctx)
 	if err != nil {
 		return err
@@ -49,11 +64,13 @@ func DeployIstioOperatorFromLocalManifest(ctx context.Context) error {
 				}
 			}
 
-			mergedResource := mergeResources(&existingResource, &resource)
-
-			err = k8sClient.Update(ctx, mergedResource)
+			err = k8sClient.Update(ctx, &resource)
 			if err != nil {
-				return err
+				if expectSuccess {
+					return err
+				} else {
+					return nil
+				}
 			}
 		}
 
@@ -84,27 +101,4 @@ func DeployIstioOperatorFromLocalManifest(ctx context.Context) error {
 		}
 		return nil
 	}, testcontext.GetRetryOpts()...)
-}
-
-func mergeResources(old, new *unstructured.Unstructured) *unstructured.Unstructured {
-	oldMap := old.Object
-	newMap := new.Object
-	mergeMaps(oldMap, newMap)
-	return &unstructured.Unstructured{Object: oldMap}
-}
-
-func mergeMaps(o, n map[string]any) {
-	for k, nv := range n {
-		if ov, ok := o[k]; ok {
-			ovm, oldIsMap := ov.(map[string]any)
-			nvm, newIsMap := nv.(map[string]any)
-			if oldIsMap && newIsMap {
-				mergeMaps(ovm, nvm)
-			} else {
-				o[k] = nv
-			}
-		} else {
-			o[k] = nv
-		}
-	}
 }

--- a/tests/integration/steps/operator.go
+++ b/tests/integration/steps/operator.go
@@ -63,7 +63,7 @@ func DeployIstioOperator(ctx context.Context, manifestType, should string) error
 					return err
 				}
 			}
-
+			resource.SetResourceVersion(existingResource.GetResourceVersion())
 			err = k8sClient.Update(ctx, &resource)
 			if err != nil {
 				if expectSuccess {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix upgrade test by not merging with existing resources but apply new manifest resources
- This way we can get errors when there are some inconsistencies, problems if we apply changes that can not be applied by k8s

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
