### PR TITLE
Update manager ClusterRole configuration

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,43 +56,92 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - config.istio.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - install.istio.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - networking.istio.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - security.istio.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - telemetry.istio.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - extensions.istio.io
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 # k8s groups
 - apiGroups:
   - admissionregistration.k8s.io
@@ -100,14 +149,28 @@ rules:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions.apiextensions.k8s.io
   - customresourcedefinitions
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   - extensions
@@ -118,13 +181,27 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -138,15 +215,36 @@ rules:
   resources:
   - poddisruptionbudgets
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  - clusterroles
   - roles
   - rolebindings
   verbs:
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  # Since the Istio installation creates the cluster role istiod-clusterrole-istio-system, for which verbs '*' is
+  # configured, we must also allow this for cluster roles.
   - '*'
 - apiGroups:
   - coordination.k8s.io
@@ -156,6 +254,7 @@ rules:
   - get
   - create
   - update
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -172,4 +271,11 @@ rules:
   - serviceaccounts
   - resourcequotas
   verbs:
-  - '*'
+  - create
+  - deletecollection
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/docs/user/technical-reference/05-10-istio-controller-rbac.md
+++ b/docs/user/technical-reference/05-10-istio-controller-rbac.md
@@ -1,0 +1,10 @@
+# Istio Controller RBAC configuration
+
+Security is paramount, so we strictly follow the least privilege principle with the Istio Controller. While it needs permissions to manage Istio resources effectively, 
+we carefully tailor them to specific tasks, avoiding unnecessary escalation to the level of all created resources.
+As the Istio Controller orchestrates the deployment of Istio components, it necessitates comprehensive management privileges for Istio resources. 
+These privileges must mirror the access control levels accorded to the resources themselves, ensuring seamless operation.
+
+## Elevated permissions for Clusterroles
+Istio's installation grants the `istiod-clusterrole-istio-system` broad permissions by using `*` verbs for accessing the `ingresses/status` resource in the `networking.k8s.io` API group.
+The ClusterRole of the Istio controller therefore also requires broad cluster role permissions ('*').

--- a/docs/user/technical-reference/README.md
+++ b/docs/user/technical-reference/README.md
@@ -2,3 +2,4 @@
 
 In this section, you can find the technical reference documents that might come in handy when using the Istio module:
 - [Istio Controller parameters](./05-00-istio-controller-parameters.md)
+- [Istio Controller RBAC configuration](./05-10-istio-controller-rbac.md)

--- a/internal/reconciliations/istio/client.go
+++ b/internal/reconciliations/istio/client.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sync"
+	"time"
 
 	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/istioctl/pkg/install/k8sversion"
@@ -70,7 +71,7 @@ func (c *IstioClient) Install(mergedIstioOperatorPath string) error {
 	iopFileNames := make([]string, 0, 1)
 	iopFileNames = append(iopFileNames, mergedIstioOperatorPath)
 	// We don't want to verify after installation, because it is unreliable
-	installArgs := &istio.InstallArgs{SkipConfirmation: true, Verify: false, InFilenames: iopFileNames}
+	installArgs := &istio.InstallArgs{ReadinessTimeout: 150 * time.Second, SkipConfirmation: true, Verify: false, InFilenames: iopFileNames}
 
 	if err := istio.Install(cliClient, &istio.RootArgs{}, installArgs, c.istioLogOptions, os.Stdout, c.consoleLogger, c.printer); err != nil {
 		return err


### PR DESCRIPTION
Add timeout to Istio install.
Add documentation about controller RBAC.

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove unnecessary `'*'` verb configuration from Istio manager ClusterRole
- Add documentation about required `'*'` configuration in Istio manager ClusterRole
- Add timeout to Istio installation so it will not hang forever and the reconciliation loop will continue.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
