### PR TITLE
Set state to warning when more than one Istio CR is defined

### DIFF
--- a/controllers/istio_controller.go
+++ b/controllers/istio_controller.go
@@ -108,7 +108,7 @@ func (r *IstioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		oldestCr := r.getOldestCR(existingIstioCRs)
 		if istioCR.GetUID() != oldestCr.GetUID() {
 			errNotOldestCR := fmt.Errorf("only Istio CR %s in %s reconciles the module", oldestCr.GetName(), oldestCr.GetNamespace())
-			return r.terminateReconciliation(ctx, &istioCR, described_errors.NewDescribedError(errNotOldestCR, "Stopped Istio CR reconciliation"),
+			return r.terminateReconciliation(ctx, &istioCR, described_errors.NewDescribedError(errNotOldestCR, "Stopped Istio CR reconciliation").SetWarning(),
 				operatorv1alpha1.NewReasonWithMessage(operatorv1alpha1.ConditionReasonOlderCRExists))
 		}
 	}

--- a/controllers/istio_controller_test.go
+++ b/controllers/istio_controller_test.go
@@ -599,7 +599,7 @@ var _ = Describe("Istio Controller", func() {
 			err = fakeClient.Get(context.TODO(), client.ObjectKeyFromObject(newerIstioCR), &updatedIstioCR)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Expect(updatedIstioCR.Status.State).Should(Equal(operatorv1alpha1.Error))
+			Expect(updatedIstioCR.Status.State).Should(Equal(operatorv1alpha1.Warning))
 			Expect(updatedIstioCR.Status.Description).To(ContainSubstring(fmt.Sprintf("only Istio CR %s in %s reconciles the module", istioCrName, testNamespace)))
 
 			Expect(updatedIstioCR.Status.Conditions).ToNot(BeNil())

--- a/tests/integration/features/istio/production/main-suite/istio_installation.feature
+++ b/tests/integration/features/istio/production/main-suite/istio_installation.feature
@@ -100,7 +100,7 @@ Feature: Installing and uninstalling Istio module
     Given Istio CR "istio-sample" is applied in namespace "kyma-system"
     And Istio CR "istio-sample" in namespace "kyma-system" has status "Ready"
     When Istio CR "istio-sample-new" is applied in namespace "kyma-system"
-    Then Istio CR "istio-sample-new" in namespace "kyma-system" has status "Error"
+    Then Istio CR "istio-sample-new" in namespace "kyma-system" has status "Warning"
     And Istio CR "istio-sample-new" in namespace "kyma-system" has condition with reason "OlderCRExists" of type "Ready" and status "False"
     And Istio CR "istio-sample-new" in namespace "kyma-system" has description "Stopped Istio CR reconciliation: only Istio CR istio-sample in kyma-system reconciles the module"
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Warning status on an Istio CR when there is more than one defined

**Related issues**
#613 