### PR TITLE
docs: Enable access logs for the whole mesh and verify the telemetry resource

### DIFF
--- a/docs/user/operation-guides/02-30-enable-istio-access-logs.md
+++ b/docs/user/operation-guides/02-30-enable-istio-access-logs.md
@@ -29,56 +29,91 @@ Use the Telemetry API to selectively enable Istio access logs. You can enable ac
 ### Configure Istio Access Logs for the Entire Namespace
 
 1. In the following sample configuration, replace `{YOUR_NAMESPACE}` with your namespace.
-2. To apply the configuration, run `kubectl apply`.
+1. To apply the configuration, run `kubectl apply`.
 
-```yaml
-apiVersion: telemetry.istio.io/v1alpha1
-kind: Telemetry
-metadata:
-  name: access-config
-  namespace: {YOUR_NAMESPACE}
-spec:
-  accessLogging:
-    - providers:
-      - name: stdout-json
-```
+    ```yaml
+    apiVersion: telemetry.istio.io/v1alpha1
+    kind: Telemetry
+    metadata:
+      name: access-config
+      namespace: {YOUR_NAMESPACE}
+    spec:
+      accessLogging:
+        - providers:
+          - name: stdout-json
+    ```
+1. To verify that the resource is applied, run:
+    ```yaml
+    kubectl -n {YOUR_NAMESPACE} get telemetries.telemetry.istio.io
+    ```
 
 ### Configure Istio Access Logs for a Selective Workload
 
 To configure label-based selection of workloads, use a [selector](https://istio.io/latest/docs/reference/config/type/workload-selector/#WorkloadSelector).
 1. In the following sample configuration, replace `{YOUR_NAMESPACE}` and `{YOUR_LABEL}` with your namespace and the label of the workload, respectively.
-2. To apply the configuration, run `kubectl apply`.
-
-```yaml
-apiVersion: telemetry.istio.io/v1alpha1
-kind: Telemetry
-metadata:
-  name: access-config
-  namespace: {YOUR_NAMESPACE}
-spec:
-  selector:
-    matchLabels:
-      service.istio.io/canonical-name: {YOUR_LABEL}
-  accessLogging:
-    - providers:
-      - name: stdout-json
-```
+1. To apply the configuration, run `kubectl apply`.
+    ```yaml
+    apiVersion: telemetry.istio.io/v1alpha1
+    kind: Telemetry
+    metadata:
+      name: access-config
+      namespace: {YOUR_NAMESPACE}
+    spec:
+      selector:
+        matchLabels:
+          service.istio.io/canonical-name: {YOUR_LABEL}
+      accessLogging:
+        - providers:
+          - name: stdout-json
+    ```
+1. To verify that the resource is applied, run:
+    ```yaml
+    kubectl -n {YOUR_NAMESPACE} get telemetries.telemetry.istio.io
+    ```
 
 ### Configure Istio Access Logs for a Specific Gateway
 
-Instead of enabling the access logs for all the individual proxies of the workloads you have, you can enable the logs for the proxy used by the related Istio Ingress Gateway:
+Instead of enabling the access logs for all the individual proxies of the workloads you have, you can enable the logs for the proxy used by the related Istio Ingress Gateway.
 
-```yaml
-apiVersion: telemetry.istio.io/v1alpha1
-kind: Telemetry
-metadata:
-  name: access-config
-  namespace: istio-system
-spec:
-  selector:
-    matchLabels:
-      istio: ingressgateway
-  accessLogging:
-    - providers:
-      - name: stdout-json
-```
+1. To apply the configuration, run `kubectl apply`.
+    ```yaml
+    apiVersion: telemetry.istio.io/v1alpha1
+    kind: Telemetry
+    metadata:
+      name: access-config
+      namespace: istio-system
+    spec:
+      selector:
+        matchLabels:
+          istio: ingressgateway
+      accessLogging:
+        - providers:
+          - name: stdout-json
+    ```
+1. To verify that the resource is applied, run:
+    ```yaml
+    kubectl -n istio-system get telemetries.telemetry.istio.io
+    ```
+
+### Configure Istio Access Logs for the Entire Mesh
+
+Enable access logs for all individual proxies of the workloads and Istio Ingress Gateways.
+1. To apply the configuration, run `kubectl apply`.
+    ```yaml
+    apiVersion: telemetry.istio.io/v1alpha1
+    kind: Telemetry
+    metadata:
+      name: access-config
+      namespace: istio-system
+    spec:
+      selector:
+        matchLabels:
+          istio: ingressgateway
+      accessLogging:
+        - providers:
+          - name: stdout-json
+    ```
+1. To verify that the resource is applied, run:
+    ```yaml
+    kubectl -n istio-system get telemetries.telemetry.istio.io
+    ```


### PR DESCRIPTION


<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add a section on how to enable access logs for the whole service mesh
- Add a verification call to the examples as for retrieval of the resource the full qualified name must be used. The resource name is clashing with a resource of the telemetry module and people are confused that there is no resource available after creation.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
