### PR TITLE
Re-introduce resource tests for sidecars

### DIFF
--- a/tests/integration/features/istio/evaluation/istio_installation_demo.feature
+++ b/tests/integration/features/istio/evaluation/istio_installation_demo.feature
@@ -6,16 +6,15 @@ Feature: Installing Istio module with evaluation profile
     And "Deployment" "istio-controller-manager" in namespace "kyma-system" is ready
 
   Scenario: Installation of istio module with evaluation profile
-    When Istio CR "istio-sample" from "istio_cr_template" is applied in namespace "kyma-system"
-    Then Istio CR "istio-sample" in namespace "kyma-system" has status "Ready"
+    Given Istio CR "istio-sample" from "istio_cr_template" is applied in namespace "kyma-system"
+    And Istio CR "istio-sample" in namespace "kyma-system" has status "Ready"
     And Istio CR "istio-sample" in namespace "kyma-system" has condition with reason "ReconcileSucceeded" of type "Ready" and status "True"
-    #Then "proxy" has "requests" set to cpu - "10m" and memory - "32Mi"
-    #And "proxy" has "limits" set to cpu - "250m" and memory - "254Mi"
-    Then "ingress-gateway" has "requests" set to cpu - "10m" and memory - "32Mi"
+    And Istio injection is "enabled" in namespace "default"
+    And Httpbin application "httpbin" deployment is created in namespace "default"
+    When "Deployment" "httpbin" in namespace "default" is ready
+    Then Pod of Deployment "httpbin" in namespace "default" has container "istio-proxy" with resource "requests" set to cpu - "10m" and memory - "32Mi"
+    And Pod of Deployment "httpbin" in namespace "default" has container "istio-proxy" with resource "limits" set to cpu - "250m" and memory - "254Mi"
+    And "ingress-gateway" has "requests" set to cpu - "10m" and memory - "32Mi"
     And "ingress-gateway" has "limits" set to cpu - "1000m" and memory - "1024Mi"
-    #And "proxy_init" has "requests" set to cpu - "10m" and memory - "10Mi"
-    #And "proxy_init" has "limits" set to cpu - "100m" and memory - "50Mi"
     And "pilot" has "requests" set to cpu - "50m" and memory - "128Mi"
     And "pilot" has "limits" set to cpu - "1000m" and memory - "1024Mi"
-    #And "egress-gateway" has "requests" set to cpu - "10m" and memory - "120Mi"
-    #And "egress-gateway" has "limits" set to cpu - "2000m" and memory - "1024Mi"

--- a/tests/integration/features/istio/production/main-suite/istio_installation.feature
+++ b/tests/integration/features/istio/production/main-suite/istio_installation.feature
@@ -9,19 +9,18 @@ Feature: Installing and uninstalling Istio module
 
   Scenario: Installation of Istio module with default values
     Given Istio CR "istio-sample" from "istio_cr_template" is applied in namespace "kyma-system"
-    Then Istio CR "istio-sample" in namespace "kyma-system" has condition with reason "ReconcileUnknown" of type "Ready" and status "Unknown"
+    And Istio CR "istio-sample" in namespace "kyma-system" has condition with reason "ReconcileUnknown" of type "Ready" and status "Unknown"
     And Istio CR "istio-sample" in namespace "kyma-system" has status "Ready"
     And Istio CR "istio-sample" in namespace "kyma-system" has condition with reason "ReconcileSucceeded" of type "Ready" and status "True"
-    #And "proxy" has "requests" set to cpu - "10m" and memory - "192Mi"
-    #And "proxy" has "limits" set to cpu - "1000m" and memory - "1024Mi"
+    And Istio injection is "enabled" in namespace "default"
+    And Httpbin application "httpbin" deployment is created in namespace "default"
+    When "Deployment" "httpbin" in namespace "default" is ready
+    Then Pod of Deployment "httpbin" in namespace "default" has container "istio-proxy" with resource "requests" set to cpu - "10m" and memory - "192Mi"
+    And Pod of Deployment "httpbin" in namespace "default" has container "istio-proxy" with resource "limits" set to cpu - "1000m" and memory - "1024Mi"
     And "ingress-gateway" has "requests" set to cpu - "100m" and memory - "128Mi"
     And "ingress-gateway" has "limits" set to cpu - "2000m" and memory - "1024Mi"
-    #And "proxy_init" has "requests" set to cpu - "10m" and memory - "10Mi"
-    #And "proxy_init" has "limits" set to cpu - "100m" and memory - "50Mi"
     And "pilot" has "requests" set to cpu - "100m" and memory - "512Mi"
     And "pilot" has "limits" set to cpu - "4000m" and memory - "2048Mi"
-    #And "egress-gateway" has "requests" set to cpu - "10m" and memory - "120Mi"
-    #And "egress-gateway" has "limits" set to cpu - "2000m" and memory - "1024Mi"
 
   Scenario: Installation of Istio module
     Given Template value "PilotCPULimit" is set to "1200m"

--- a/tests/integration/scenario.go
+++ b/tests/integration/scenario.go
@@ -25,6 +25,7 @@ func initScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^Namespace "([^"]*)" has "([^"]*)" label and "([^"]*)" annotation`, steps.NamespaceHasLabelAndAnnotation)
 	ctx.Step(`^Istio CRDs "([^"]*)" be present on cluster$`, steps.IstioCRDsBePresentOnCluster)
 	ctx.Step(`^"([^"]*)" has "([^"]*)" set to cpu - "([^"]*)" and memory - "([^"]*)"$`, steps.IstioComponentHasResourcesSetToCpuAndMemory)
+	ctx.Step(`^Pod of Deployment "([^"]*)" in namespace "([^"]*)" has container "([^"]*)" with resource "([^"]*)" set to cpu - "([^"]*)" and memory - "([^"]*)"$`, steps.DeploymentHasPodWithContainerResourcesSetToCpuAndMemory)
 	ctx.Step(`^"([^"]*)" "([^"]*)" in namespace "([^"]*)" is deleted$`, steps.ResourceInNamespaceIsDeleted)
 	ctx.Step(`^"([^"]*)" "([^"]*)" is deleted$`, steps.ClusterResourceIsDeleted)
 	ctx.Step(`^"([^"]*)" is not present on cluster$`, steps.ResourceNotPresent)

--- a/tests/integration/steps/container_resources.go
+++ b/tests/integration/steps/container_resources.go
@@ -1,0 +1,96 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-project/istio/operator/tests/integration/testcontext"
+	"github.com/pkg/errors"
+	"gopkg.in/inf.v0"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
+	"strings"
+)
+
+type resourceStruct struct {
+	Cpu    resource.Quantity
+	Memory resource.Quantity
+}
+
+func DeploymentHasPodWithContainerResourcesSetToCpuAndMemory(ctx context.Context, depName, depNamespace, container, resourceType, cpu, memory string) error {
+	k8sClient, err := testcontext.GetK8sClientFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	podList := &v1.PodList{}
+	opts := []client.ListOption{
+		client.InNamespace(depNamespace),
+		client.MatchingLabels{"app": depName},
+	}
+	if err := k8sClient.List(context.Background(), podList, opts...); err != nil {
+		return err
+	}
+
+	if len(podList.Items) == 0 {
+		return errors.Errorf("no pods found for deployment %s/%s", depNamespace, depName)
+	}
+
+	pod := podList.Items[0]
+	resources, err := getContainerResources(pod, container, resourceType)
+	if err != nil {
+		return err
+	}
+
+	if err := assertResources(resources, cpu, memory); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("assert %s resources of container %s in pod %s/%s", resourceType, container, pod.Namespace, pod.Name))
+	}
+	return nil
+}
+
+func getContainerResources(pod v1.Pod, container, resourceType string) (resourceStruct, error) {
+	for _, c := range pod.Spec.Containers {
+		if c.Name == container {
+			switch resourceType {
+			case "limits":
+				return resourceStruct{
+					Cpu:    *c.Resources.Limits.Cpu(),
+					Memory: *c.Resources.Limits.Memory(),
+				}, nil
+			case "requests":
+				return resourceStruct{
+					Cpu:    *c.Resources.Requests.Cpu(),
+					Memory: *c.Resources.Requests.Memory(),
+				}, nil
+			default:
+				return resourceStruct{}, fmt.Errorf("resource type %s is not supported", resourceType)
+			}
+		}
+	}
+
+	return resourceStruct{}, fmt.Errorf("container istio-proxy not found in pod %s/%s", pod.Namespace, pod.Name)
+}
+
+func assertResources(actualResources resourceStruct, expectedCpu, expectedMemory string) error {
+
+	cpuMilli, err := strconv.Atoi(strings.TrimSuffix(expectedCpu, "m"))
+	if err != nil {
+		return err
+	}
+
+	memMilli, err := strconv.Atoi(strings.TrimSuffix(expectedMemory, "Mi"))
+	if err != nil {
+		return err
+	}
+
+	if resource.NewDecimalQuantity(*inf.NewDec(int64(cpuMilli), inf.Scale(resource.Milli)), resource.DecimalSI).Equal(actualResources.Cpu) {
+		return fmt.Errorf("cpu wasn't expected; expected=%v got=%v", resource.NewScaledQuantity(int64(cpuMilli), resource.Milli), actualResources.Cpu)
+	}
+
+	if resource.NewDecimalQuantity(*inf.NewDec(int64(memMilli), inf.Scale(resource.Milli)), resource.DecimalSI).Equal(actualResources.Memory) {
+		return fmt.Errorf("memory wasn't expected; expected=%v got=%v", resource.NewScaledQuantity(int64(memMilli), resource.Milli), actualResources.Memory)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add new generic step to verify container resources
- Add step for istio proxy resource verification
- Remove egress-gateway resource verification, because egress is not enabled
- Remove proxy_init resource verification, because we have cni enabled per default and therefore proxy_init container will not be used

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/istio/issues/721