### PR TITLE
fix: Use a custom path for telemetries UI to avoid conflicts with kyma telemetry resources

### DIFF
--- a/config/ui-extensions/telemetries/general
+++ b/config/ui-extensions/telemetries/general
@@ -2,7 +2,7 @@ resource:
   kind: Telemetry
   group: telemetry.istio.io
   version: v1alpha1
-urlPath: telemetries
+urlPath: istiotelemetries
 category: Istio
 name: Telemetries
 scope: namespace

--- a/tests/ui/support/navigation.ts
+++ b/tests/ui/support/navigation.ts
@@ -37,14 +37,14 @@ Cypress.Commands.add('navigateToAuthorizationPolicies', (namespace: string): voi
 
 Cypress.Commands.add('navigateToTelemetries', (namespace: string): void => {
     cy.wrap(getK8sCurrentContext()).then((context) => {
-        cy.visit(`${config.clusterAddress}/cluster/${context}/namespaces/${namespace}/telemetries`)
+        cy.visit(`${config.clusterAddress}/cluster/${context}/namespaces/${namespace}/istiotelemetries`)
         cy.wait(2000);
     });
 });
 
 Cypress.Commands.add('navigateToTelemetry', (namespace: string, name: string): void => {
     cy.wrap(getK8sCurrentContext()).then((context) => {
-        cy.visit(`${config.clusterAddress}/cluster/${context}/namespaces/${namespace}/telemetries/${name}`)
+        cy.visit(`${config.clusterAddress}/cluster/${context}/namespaces/${namespace}/istiotelemetries/${name}`)
         cy.wait(2000);
     });
 });


### PR DESCRIPTION

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
With https://github.com/kyma-project/istio/issues/579 a new UI for istio telemetry resources was introduced. The UI is in conflict with Kyma telemetry resources as they share the same URL path.

With https://github.com/kyma-project/telemetry-manager/pull/1092 we tried to change the path for the kyma resources. The actual navigation node is fixed indeed, however, the module UI of the dashboard does ignore that setting and build up links on the plural of the CRD and is still broken.

As fixing the dashboard will take time, this PR is adjusting the path for the istio resource as they are not used in the module UI, so that the kyma resource path can be reverted back.

<img width="1361" alt="Screenshot 2024-06-03 at 14 19 21" src="https://github.com/kyma-project/istio/assets/7479371/80cf8e4b-9ad1-42c6-9d6e-0a1e9021f09c">




Changes proposed in this pull request:

- change path from "telemetries" to "istiotelemetries" for telemetry UI

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
