### PR TITLE
Disable test controller restart verification hook

### DIFF
--- a/tests/integration/hooks.go
+++ b/tests/integration/hooks.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kyma-project/istio/operator/api/v1alpha2"
 	"github.com/kyma-project/istio/operator/tests/integration/testcontext"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,28 +68,29 @@ var istioCrTearDown = func(ctx context.Context, sc *godog.Scenario, _ error) (co
 }
 
 var verifyIfControllerHasBeenRestarted = func(ctx context.Context, sc *godog.Scenario, _ error) (context.Context, error) {
-	c, err := testcontext.GetK8sClientFromContext(ctx)
-	if err != nil {
-		return ctx, err
-	}
-
-	podList := &corev1.PodList{}
-	err = c.List(ctx, podList, client.MatchingLabels{"app.kubernetes.io/component": "istio-operator.kyma-project.io"})
-	if err != nil {
-		return ctx, err
-	}
-	if len(podList.Items) < 1 {
-		return ctx, errors.New("Controller not found")
-	}
-
-	for _, cpod := range podList.Items {
-		if len(cpod.Status.ContainerStatuses) > 0 {
-			if rc := cpod.Status.ContainerStatuses[0].RestartCount; rc > 0 {
-				errMsg := fmt.Sprintf("Controller has been restarted %d times", rc)
-				return ctx, errors.New(errMsg)
-			}
-		}
-	}
+	// The hook verifyIfControllerHasBeenRestarted caused flakiness in the tests. To unblock PRs during the investigation, it was disabled.
+	//c, err := testcontext.GetK8sClientFromContext(ctx)
+	//if err != nil {
+	//	return ctx, err
+	//}
+	//
+	//podList := &corev1.PodList{}
+	//err = c.List(ctx, podList, client.MatchingLabels{"app.kubernetes.io/component": "istio-operator.kyma-project.io"})
+	//if err != nil {
+	//	return ctx, err
+	//}
+	//if len(podList.Items) < 1 {
+	//	return ctx, errors.New("Controller not found")
+	//}
+	//
+	//for _, cpod := range podList.Items {
+	//	if len(cpod.Status.ContainerStatuses) > 0 {
+	//		if rc := cpod.Status.ContainerStatuses[0].RestartCount; rc > 0 {
+	//			errMsg := fmt.Sprintf("Controller has been restarted %d times", rc)
+	//			return ctx, errors.New(errMsg)
+	//		}
+	//	}
+	//}
 
 	return ctx, nil
 }

--- a/tests/integration/scenario.go
+++ b/tests/integration/scenario.go
@@ -6,7 +6,8 @@ import (
 )
 
 func initScenario(ctx *godog.ScenarioContext) {
-	ctx.After(verifyIfControllerHasBeenRestarted)
+	// The hook verifyIfControllerHasBeenRestarted caused flakiness in the tests. To unblock PRs during the investigation, it was disabled.
+	//ctx.After(verifyIfControllerHasBeenRestarted)
 	ctx.After(testObjectsTearDown)
 	ctx.After(istioCrTearDown)
 
@@ -56,7 +57,8 @@ func initScenario(ctx *godog.ScenarioContext) {
 }
 
 func upgradeInitScenario(ctx *godog.ScenarioContext) {
-	ctx.After(verifyIfControllerHasBeenRestarted)
+	// The hook verifyIfControllerHasBeenRestarted caused flakiness in the tests. To unblock PRs during the investigation, it was disabled.
+	//ctx.After(verifyIfControllerHasBeenRestarted)
 	ctx.After(testObjectsTearDown)
 	ctx.After(istioCrTearDown)
 

--- a/tests/integration/scenario.go
+++ b/tests/integration/scenario.go
@@ -6,8 +6,7 @@ import (
 )
 
 func initScenario(ctx *godog.ScenarioContext) {
-	// The hook verifyIfControllerHasBeenRestarted caused flakiness in the tests. To unblock PRs during the investigation, it was disabled.
-	//ctx.After(verifyIfControllerHasBeenRestarted)
+	ctx.After(verifyIfControllerHasBeenRestarted)
 	ctx.After(testObjectsTearDown)
 	ctx.After(istioCrTearDown)
 
@@ -57,8 +56,7 @@ func initScenario(ctx *godog.ScenarioContext) {
 }
 
 func upgradeInitScenario(ctx *godog.ScenarioContext) {
-	// The hook verifyIfControllerHasBeenRestarted caused flakiness in the tests. To unblock PRs during the investigation, it was disabled.
-	//ctx.After(verifyIfControllerHasBeenRestarted)
+	ctx.After(verifyIfControllerHasBeenRestarted)
 	ctx.After(testObjectsTearDown)
 	ctx.After(istioCrTearDown)
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Disable hook that verifies that the controller was not restarted in integration and upgrade tests. The hook introduces flakiness in the tests and therefore we should disable during investigation to unblock PRs.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
