### PR TITLE
Remove hook that verifies if controller was restarted in integration tests

### DIFF
--- a/tests/integration/hooks.go
+++ b/tests/integration/hooks.go
@@ -67,34 +67,6 @@ var istioCrTearDown = func(ctx context.Context, sc *godog.Scenario, _ error) (co
 	return ctx, nil
 }
 
-var verifyIfControllerHasBeenRestarted = func(ctx context.Context, sc *godog.Scenario, _ error) (context.Context, error) {
-	// The hook verifyIfControllerHasBeenRestarted caused flakiness in the tests. To unblock PRs during the investigation, it was disabled.
-	//c, err := testcontext.GetK8sClientFromContext(ctx)
-	//if err != nil {
-	//	return ctx, err
-	//}
-	//
-	//podList := &corev1.PodList{}
-	//err = c.List(ctx, podList, client.MatchingLabels{"app.kubernetes.io/component": "istio-operator.kyma-project.io"})
-	//if err != nil {
-	//	return ctx, err
-	//}
-	//if len(podList.Items) < 1 {
-	//	return ctx, errors.New("Controller not found")
-	//}
-	//
-	//for _, cpod := range podList.Items {
-	//	if len(cpod.Status.ContainerStatuses) > 0 {
-	//		if rc := cpod.Status.ContainerStatuses[0].RestartCount; rc > 0 {
-	//			errMsg := fmt.Sprintf("Controller has been restarted %d times", rc)
-	//			return ctx, errors.New(errMsg)
-	//		}
-	//	}
-	//}
-
-	return ctx, nil
-}
-
 func forceIstioCrRemoval(ctx context.Context, istio *v1alpha2.Istio) error {
 	c, err := testcontext.GetK8sClientFromContext(ctx)
 	if err != nil {

--- a/tests/integration/scenario.go
+++ b/tests/integration/scenario.go
@@ -6,7 +6,6 @@ import (
 )
 
 func initScenario(ctx *godog.ScenarioContext) {
-	ctx.After(verifyIfControllerHasBeenRestarted)
 	ctx.After(testObjectsTearDown)
 	ctx.After(istioCrTearDown)
 
@@ -56,7 +55,6 @@ func initScenario(ctx *godog.ScenarioContext) {
 }
 
 func upgradeInitScenario(ctx *godog.ScenarioContext) {
-	ctx.After(verifyIfControllerHasBeenRestarted)
 	ctx.After(testObjectsTearDown)
 	ctx.After(istioCrTearDown)
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove verifyIfControllerHasBeenRestarted  since it became unreliable on Gardener and made the tests flaky

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
