### PR TITLE
Remove dependency to Prow in Pull Request workflows

### DIFF
--- a/.github/actions/build-manager-image/action.yaml
+++ b/.github/actions/build-manager-image/action.yaml
@@ -1,0 +1,64 @@
+name: 'Build Istio Manager Image'
+description: 'Builds Istio manager image'
+inputs:
+  operator-image-name:
+    description: 'Operator image name used for creation of Istio manager image'
+    required: true
+  platforms:
+    description: 'Platforms to build the image for (comma-separated), e.g. linux/amd64,linux/arm64,linux/arm/v7'
+    required: false
+    default: 'linux/amd64'
+  push-image:
+    description: 'Push the image to GCP'
+    required: false
+    default: 'false'
+  push-sa-key:
+    description: 'Service account key to push the image to GCP'
+    required: false
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      if: ${{ inputs.push-image == 'true' }}
+      uses: docker/login-action@v3
+      with:
+        registry: europe-central2-docker.pkg.dev
+        username: _json_key_base64
+        password: ${{ inputs.push-sa-key }}
+    - name: Build and Push
+      if: ${{ inputs.push-image == 'true' }}
+      uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_NO_SUMMARY: false
+      with:
+        context: .
+        platforms: ${{ inputs.platforms }}
+        push: true
+        tags: ${{ inputs.operator-image-name }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+    - name: Build and Load
+      if: ${{ inputs.push-image == 'false' }}
+      uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_NO_SUMMARY: false
+      with:
+        context: .
+        platforms: ${{ inputs.platforms }}
+        push: false
+        load: true
+        tags: ${{ inputs.operator-image-name }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        outputs: type=docker,dest=/tmp/manager-image.tar
+    - name: Upload artifact
+      if: ${{ inputs.push-image == 'false' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: manager-image
+        path: /tmp/manager-image.tar

--- a/.github/actions/build-manager-image/action.yaml
+++ b/.github/actions/build-manager-image/action.yaml
@@ -33,8 +33,6 @@ runs:
     - name: Build and Push
       if: ${{ inputs.push-image == 'true' }}
       uses: docker/build-push-action@v6
-      env:
-        DOCKER_BUILD_NO_SUMMARY: false
       with:
         context: .
         platforms: ${{ inputs.platforms }}
@@ -45,8 +43,6 @@ runs:
     - name: Build and Load
       if: ${{ inputs.push-image == 'false' }}
       uses: docker/build-push-action@v6
-      env:
-        DOCKER_BUILD_NO_SUMMARY: false
       with:
         context: .
         platforms: ${{ inputs.platforms }}

--- a/.github/actions/integration-test/action.yaml
+++ b/.github/actions/integration-test/action.yaml
@@ -34,6 +34,7 @@ runs:
     - name: Run integration tests
       shell: bash
       run: |
+        k3d image import ${{ inputs.operator-image-name }} -c test-cluster-1
         kubectl config use-context k3d-test-cluster-1
         if "${{ inputs.evaluation }}" == "true"; then
           TEST_EVALUATION=TRUE EXPORT_RESULT=true IMG=${{ inputs.operator-image-name }} make istio-integration-test

--- a/.github/actions/k8s-compatibility-test/action.yaml
+++ b/.github/actions/k8s-compatibility-test/action.yaml
@@ -23,6 +23,7 @@ runs:
           --k3s-arg "--disable=traefik@server:0"
     - name: Run integration tests
       run: |
+        k3d image import ${{ inputs.operator-image-name }} -c test-cluster-1
         kubectl config use-context k3d-test-cluster-1
         EXPORT_RESULT=true IMG=${{ inputs.operator-image-name }} make istio-integration-test
       shell: bash

--- a/.github/actions/load-manager-image/action.yaml
+++ b/.github/actions/load-manager-image/action.yaml
@@ -1,0 +1,14 @@
+name: 'Load Istio Manager Image'
+description: 'Load Istio manage image from a tar archive in the artifacts'
+runs:
+  using: "composite"
+  steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: manager-image
+        path: /tmp
+    - name: Load image
+      shell: bash
+      run: |
+        docker load --input /tmp/manager-image.tar

--- a/.github/actions/upgrade-integration-test/action.yaml
+++ b/.github/actions/upgrade-integration-test/action.yaml
@@ -22,6 +22,7 @@ runs:
           --k3s-arg "--disable=traefik@server:0"
     - name: Run upgrade integration test
       run: |
+        k3d image import ${{ inputs.operator-image-name }} -c test-cluster-1
         kubectl config use-context k3d-test-cluster-1
         EXPORT_RESULT=true IMG=${{ inputs.operator-image-name }} TARGET_BRANCH=${{inputs.target_branch}} make istio-upgrade-integration-test
       shell: bash

--- a/.github/workflows/pull-integration-gardener.yaml
+++ b/.github/workflows/pull-integration-gardener.yaml
@@ -41,12 +41,11 @@ jobs:
     if: ${{ github.event.pull_request.draft == false && needs.filter-changes.outputs.check == 'true' }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-manager-image
         with:
-          fetch-depth: 0
-      - uses: ./.github/actions/wait-for-job-succeed-or-fail
-        with:
-          job-name: 'pull-istio-operator-build'
-          github-auth-token: ${{ secrets.GITHUB_TOKEN }}
+          operator-image-name: "europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}"
+          push-image: 'true'
+          push-sa-key: ${{ secrets.GCP_SA_KEY }}
 
   istio-integration-gcp:
     name: Istio integration test GCP
@@ -64,7 +63,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - run: make IMG="europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}" gardener-istio-integration-test
+      - run: make IMG="europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}" gardener-istio-integration-test
         shell: bash
         env:
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
@@ -95,7 +94,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - run: make IMG="europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}" gardener-aws-integration-test
+      - run: make IMG="europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}" gardener-aws-integration-test
         shell: bash
         env:
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
@@ -126,7 +125,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - run: make IMG="europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}" gardener-gcp-integration-test
+      - run: make IMG="europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}" gardener-gcp-integration-test
         shell: bash
         env:
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"

--- a/.github/workflows/pull-integration.yaml
+++ b/.github/workflows/pull-integration.yaml
@@ -12,9 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/load-manager-image
       - uses: ./.github/actions/k8s-compatibility-test
         with:
-          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          operator-image-name: "istio-manager:PR-${{github.event.number}}"
 
   istio-upgrade-integration-test:
     name: Istio upgrade integration test
@@ -23,9 +24,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/load-manager-image
       - uses: ./.github/actions/upgrade-integration-test
         with:
-          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          operator-image-name: "istio-manager:PR-${{github.event.number}}"
           target_branch: ${{ github.base_ref }}
 
   istio-integration-test:
@@ -35,10 +37,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/load-manager-image
       - uses: ./.github/actions/integration-test
         with:
           evaluation: false
-          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          operator-image-name: "istio-manager:PR-${{github.event.number}}"
           servers-memory: "16g"
           agents: 2
 
@@ -49,9 +52,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/load-manager-image
       - uses: ./.github/actions/integration-test
         with:
           evaluation: true
-          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          operator-image-name: "istio-manager:PR-${{github.event.number}}"
           servers-memory: "4g"
           agents: 0

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -20,9 +20,11 @@ jobs:
           files_ignore: |
              docs/**
              **/*.md
+             **/*.yaml
              tests/performance/**
              OWNERS
              CODEOWNERS
+             .github/**
              .reuse/**
       - name: List all changed files
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
@@ -85,6 +87,7 @@ jobs:
             OWNERS
             CODEOWNERS
             sec-scanners-config.yaml
+            .github/**
             .reuse/**
       - name: List all changed files
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
@@ -111,7 +114,6 @@ jobs:
             config/crd/**
             tests/ui/**
             .github/workflows/ui-tests.yaml
-            .github/**
       - name: List all changed files
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
   dispatch-ui:
@@ -167,11 +169,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-push-manager-image,wait-for-image-build]
     if: ${{ needs.check-wait-for-image-build.outputs.check== 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-manager-image
         with:
           operator-image-name: "europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}"
-          platforms: 'linux/amd64'
+          platforms: ${{ matrix.platform }}
           push-image: 'true'
           push-sa-key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -158,9 +158,11 @@ jobs:
           files_ignore: |
             docs/**
             **/*.md
+            **/*.yaml
             tests/performance/**
             OWNERS
             CODEOWNERS
+            .github/**
             .reuse/**
       - name: List all changed files
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
@@ -169,17 +171,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-push-manager-image,wait-for-image-build]
     if: ${{ needs.check-wait-for-image-build.outputs.check== 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-manager-image
         with:
           operator-image-name: "europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}"
-          platforms: ${{ matrix.platform }}
           push-image: 'true'
           push-sa-key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -20,11 +20,9 @@ jobs:
           files_ignore: |
              docs/**
              **/*.md
-             **/*.yaml
              tests/performance/**
              OWNERS
              CODEOWNERS
-             .github/**
              .reuse/**
       - name: List all changed files
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
@@ -36,10 +34,9 @@ jobs:
     if: ${{ needs.check-wait-for-image-build.outputs.check== 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/wait-for-job-succeed-or-fail
+      - uses: ./.github/actions/build-manager-image
         with:
-          job-name: 'pull-istio-operator-build'
-          github-auth-token: ${{ secrets.GITHUB_TOKEN }}
+          operator-image-name: "istio-manager:PR-${{github.event.number}}"
 
   check-unit-test:
     outputs:
@@ -88,7 +85,6 @@ jobs:
             OWNERS
             CODEOWNERS
             sec-scanners-config.yaml
-            .github/**
             .reuse/**
       - name: List all changed files
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
@@ -115,6 +111,7 @@ jobs:
             config/crd/**
             tests/ui/**
             .github/workflows/ui-tests.yaml
+            .github/**
       - name: List all changed files
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
   dispatch-ui:
@@ -144,3 +141,37 @@ jobs:
     uses: ./.github/workflows/verify-commit-pins.yaml
     if: ${{ needs.check-verify-pins.outputs.check == 'true' }}
     secrets: inherit
+
+  check-push-manager-image:
+    outputs:
+      check: ${{ steps.changed-files.outputs.any_modified }}
+    name: Check whether to run push-manager-image
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@d6babd6899969df1a11d14c368283ea4436bca78
+        id: changed-files
+        with:
+          files_ignore: |
+            docs/**
+            **/*.md
+            tests/performance/**
+            OWNERS
+            CODEOWNERS
+            .reuse/**
+      - name: List all changed files
+        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
+  dispatch-push-manager-image:
+    name: Dispatch push manager image to GCP
+    runs-on: ubuntu-latest
+    needs: [check-push-manager-image,wait-for-image-build]
+    if: ${{ needs.check-wait-for-image-build.outputs.check== 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-manager-image
+        with:
+          operator-image-name: "europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}"
+          platforms: 'linux/amd64'
+          push-image: 'true'
+          push-sa-key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -143,38 +143,3 @@ jobs:
     uses: ./.github/workflows/verify-commit-pins.yaml
     if: ${{ needs.check-verify-pins.outputs.check == 'true' }}
     secrets: inherit
-
-  check-push-manager-image:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether to run push-manager-image
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@d6babd6899969df1a11d14c368283ea4436bca78
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            **/*.yaml
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            .github/**
-            .reuse/**
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-push-manager-image:
-    name: Dispatch push manager image to GCP
-    runs-on: ubuntu-latest
-    needs: [check-push-manager-image,wait-for-image-build]
-    if: ${{ needs.check-wait-for-image-build.outputs.check== 'true' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/build-manager-image
-        with:
-          operator-image-name: "europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}"
-          push-image: 'true'
-          push-sa-key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/ui-tests.yaml
+++ b/.github/workflows/ui-tests.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/load-manager-image
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
@@ -18,7 +19,7 @@ jobs:
         run: |
           sudo echo "127.0.0.1 local.kyma.dev" | sudo tee -a /etc/hosts
           wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | sudo bash
-          IMG=europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{ github.event.number }} ./tests/ui/scripts/k3d-ci-kyma-dashboard-integration.sh prod
+          IMG=istio-manager:PR-${{ github.event.number }} ./tests/ui/scripts/k3d-ci-kyma-dashboard-integration.sh prod
       - uses: actions/upload-artifact@v4
         if: always()
         name: Export Cypress output

--- a/tests/ui/scripts/k3d-ci-kyma-dashboard-integration.sh
+++ b/tests/ui/scripts/k3d-ci-kyma-dashboard-integration.sh
@@ -22,6 +22,7 @@ sudo apt-get install -y gettext-base
 function deploy_k3d (){
 echo "Provisioning k3d cluster"
 sudo k3d cluster create kyma --port 80:80@loadbalancer --port 443:443@loadbalancer --k3s-arg "--disable=traefik@server:0"
+k3d image import "$IMG" -c kyma
 
 export KUBECONFIG=$(k3d kubeconfig merge kyma)
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Replace waiting for Prow job with building a Docker image and using it in the k3d integration tests in the Pull Request workflow
- Replace waiting for Prow job with building a Docker image and pushing it to GCP Artifact Registry in Gardener-based PR integration tests

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
