### PR TITLE
bug: add scripts/get_latest_build_sha.sh use to perf test

### DIFF
--- a/.github/workflows/performance-test.yaml
+++ b/.github/workflows/performance-test.yaml
@@ -21,7 +21,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-perf-test
+      - run: |
+          sha=$(./scripts/get_latest_build_sha.sh)
+          make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:$sha" gardener-perf-test
         shell: bash
         env:
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"


### PR DESCRIPTION
/kind bug
/area ci

* aadd scripts/get_latest_build_sha.sh use to perf test - for some commits build is not triggered and perf tests fail on ImagePullbackOff.

