### PR TITLE
bug: fix fetching origin in update-sec-scanner.yaml

### DIFF
--- a/.github/workflows/update-sec-scanner.yaml
+++ b/.github/workflows/update-sec-scanner.yaml
@@ -28,6 +28,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           
+          git fetch origin
           git checkout -f autobump/sec-scanners-config
           git reset --hard origin/main
           sed -i "s/europe-docker\.pkg\.dev\/kyma-project\/prod\/istio-manager\:.*/europe-docker\.pkg\.dev\/kyma-project\/prod\/istio-manager\:$IMAGE_TAG/" sec-scanners-config.yaml


### PR DESCRIPTION
/kind bug
/area ci

fixing workflow error `error: pathspec 'autobump/sec-scanners-config' did not match any file(s) known to git`. git fetch origin is missing
