### PR TITLE
bug: use proper secret in a workflow

### DIFF
--- a/.github/workflows/update-sec-scanner.yaml
+++ b/.github/workflows/update-sec-scanner.yaml
@@ -4,6 +4,7 @@ on:
     - cron: '21 * * * *'
 permissions:
   contents: write
+  pull-requests: write
 jobs:
   update-sec-scanners:
     name: update sec-scanners-config.yaml
@@ -25,7 +26,7 @@ jobs:
       - shell: bash
         name: Schedule security-config update
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
/kind bug
/area ci

It's supposed to be `${{ secrets.GITHUB_TOKEN }}`...
