### PR TITLE
Change certificate key size to 4096 bits

### DIFF
--- a/docs/release-notes/1.8.3.md
+++ b/docs/release-notes/1.8.3.md
@@ -1,0 +1,3 @@
+## New features
+
+- Change certificate key size to 4096 bits [#984](https://github.com/kyma-project/istio/pull/984)

--- a/docs/release-notes/1.8.3.md
+++ b/docs/release-notes/1.8.3.md
@@ -1,3 +1,3 @@
 ## New features
 
-- Change certificate key size to 4096 bits [#984](https://github.com/kyma-project/istio/pull/984)
+- The self-signed CA certificate's bit length is now set to `4096` instead of the default `2048`. [#984](https://github.com/kyma-project/istio/pull/984)

--- a/docs/user/00-40-overview-istio-setup.md
+++ b/docs/user/00-40-overview-istio-setup.md
@@ -15,3 +15,4 @@ These configuration changes are applied to customize Istio:
 - The use of HTTP 1.0 is enabled in the outbound HTTP listeners by the `PILOT_HTTP10` flag set in the Istiod component environment variables.
 - The [Istio custom resource (CR)](./04-00-istio-custom-resource.md) defines the kind of data used to manage Istio.
 - No Egress limitations are implemented - all applications deployed in the Kyma cluster can access outside resources without limitations.
+- The self-signed CA certificate's bit length is set to `4096` instead of the default `2048`.

--- a/internal/istiooperator/istio-operator-light.yaml
+++ b/internal/istiooperator/istio-operator-light.yaml
@@ -136,6 +136,7 @@ spec:
       holdApplicationUntilProxyStarts: true
       proxyMetadata:
         BOOTSTRAP_XDS_AGENT: "true"
+        CITADEL_SELF_SIGNED_CA_RSA_KEY_SIZE: "4096"
       tracingServiceName: CANONICAL_NAME_ONLY
     defaultProviders:
       tracing: []
@@ -315,7 +316,8 @@ spec:
       deploymentLabels: null
       enableProtocolSniffingForInbound: true
       enableProtocolSniffingForOutbound: true
-      env: {}
+      env:
+        CITADEL_SELF_SIGNED_CA_RSA_KEY_SIZE: "4096"
       image: pilot
       keepaliveMaxServerConnectionAge: 30m
       nodeSelector: {}

--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -143,6 +143,7 @@ spec:
       holdApplicationUntilProxyStarts: true
       proxyMetadata:
         BOOTSTRAP_XDS_AGENT: "true"
+        CITADEL_SELF_SIGNED_CA_RSA_KEY_SIZE: "4096"
       tracingServiceName: CANONICAL_NAME_ONLY
     defaultProviders:
       tracing: []
@@ -322,7 +323,8 @@ spec:
       deploymentLabels: null
       enableProtocolSniffingForInbound: true
       enableProtocolSniffingForOutbound: true
-      env: {}
+      env:
+        CITADEL_SELF_SIGNED_CA_RSA_KEY_SIZE: "4096"
       image: pilot
       keepaliveMaxServerConnectionAge: 30m
       nodeSelector: {}

--- a/internal/istiooperator/istiooperator.go
+++ b/internal/istiooperator/istiooperator.go
@@ -78,17 +78,17 @@ func (m *IstioMerger) GetIstioImageVersion() (IstioImageVersion, error) {
 }
 
 func (m *IstioMerger) GetIstioOperator(clusterSize clusterconfig.ClusterSize) (iopv1alpha1.IstioOperator, error) {
-	var istioOpertor []byte
+	var istioOperator []byte
 	switch clusterSize {
 	case clusterconfig.Production:
-		istioOpertor = ProductionOperator
+		istioOperator = ProductionOperator
 	case clusterconfig.Evaluation:
-		istioOpertor = EvaluationOperator
+		istioOperator = EvaluationOperator
 	default:
 		return iopv1alpha1.IstioOperator{}, errors.New("unsupported cluster size")
 	}
 	toBeInstalledIop := iopv1alpha1.IstioOperator{}
-	err := yaml.Unmarshal(istioOpertor, &toBeInstalledIop)
+	err := yaml.Unmarshal(istioOperator, &toBeInstalledIop)
 	if err != nil {
 		return iopv1alpha1.IstioOperator{}, err
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change certificate key size
- Fix typo

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
#969 

**Info**
https://istio.io/latest/docs/ops/configuration/traffic-management/manage-mesh-certificates/

Can be tested with:
```
kubectl get secrets -n istio-system istio-ca-secret --template='{{ range $key, $value := .data }}{{ printf "%s: %s\n" $key ($value | base64decode) }}{{ end }}'
```