### PR TITLE
chore: consolidate job statuses in PRs into one

### DIFF
--- a/.github/workflows/main-integration.yaml
+++ b/.github/workflows/main-integration.yaml
@@ -82,6 +82,7 @@ jobs:
       - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-istio-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAKE_TEST_TARGET: "istio-upgrade-integration-test"
           TARGET_BRANCH: ${{github.ref_name}}
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
@@ -109,6 +110,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/integration-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: ${{ matrix.test_make_target }}
           operator-image-name: "europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}"
@@ -137,6 +140,7 @@ jobs:
       - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-istio-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "goat"
@@ -168,6 +172,7 @@ jobs:
       - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-aws-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "aws-gardener-access"
@@ -198,6 +203,7 @@ jobs:
       - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-gcp-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "goat"
@@ -232,6 +238,7 @@ jobs:
       - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-istio-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "aws-gardener-access"

--- a/.github/workflows/performance-test.yaml
+++ b/.github/workflows/performance-test.yaml
@@ -38,6 +38,7 @@ jobs:
           make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{ github.sha }}" gardener-perf-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "goat"

--- a/.github/workflows/pull-integration-gardener-release.yaml
+++ b/.github/workflows/pull-integration-gardener-release.yaml
@@ -4,9 +4,31 @@ on:
   workflow_call:
 
 jobs:
+  changed-files:
+    outputs:
+      any_modified: ${{ steps.changed-files.outputs.any_modified }}
+    name: Check whether integration tests should run based on the changed files
+    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed-files
+        with:
+          files_ignore: |
+            docs/**
+            **/*.md
+            tests/performance/**
+            OWNERS
+            CODEOWNERS
+            .reuse/**
+            external-images.yaml
+
   istio-integration-gcp:
     name: Istio integration test GCP
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: ${{ needs.changed-files.outputs.any_modified }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +48,7 @@ jobs:
       - run: make gardener-istio-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMG: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
@@ -43,6 +66,8 @@ jobs:
   istio-integration-aws-specific:
     name: Istio integration test AWS specific
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: ${{ needs.changed-files.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,6 +83,7 @@ jobs:
       - run: make gardener-aws-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMG: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
@@ -74,6 +100,8 @@ jobs:
   istio-integration-gcp-specific:
     name: Istio integration test GCP specific
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: ${{ needs.changed-files.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,6 +117,7 @@ jobs:
       - run: make gardener-gcp-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMG: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"

--- a/.github/workflows/pull-integration-gardener.yaml
+++ b/.github/workflows/pull-integration-gardener.yaml
@@ -73,6 +73,7 @@ jobs:
       - run: make IMG="europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}" gardener-istio-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "goat"
@@ -105,6 +106,7 @@ jobs:
       - run: make IMG="europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}" gardener-aws-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "aws-gardener-access"
@@ -136,6 +138,7 @@ jobs:
       - run: make IMG="europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}" gardener-gcp-integration-test
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "goat"

--- a/.github/workflows/pull-integration-release.yaml
+++ b/.github/workflows/pull-integration-release.yaml
@@ -7,9 +7,31 @@ on:
   workflow_call:
 
 jobs:
+  changed-files:
+    outputs:
+      any_modified: ${{ steps.changed-files.outputs.any_modified }}
+    name: Check whether integration tests should run based on the changed files
+    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed-files
+        with:
+          files_ignore: |
+            docs/**
+            **/*.md
+            tests/performance/**
+            OWNERS
+            CODEOWNERS
+            .reuse/**
+            external-images.yaml
+
   k8s-compatibility-test:
     name: Kubernetes version compatibility test
     runs-on: ubuntu-latest
+    needs: [changed-files]
+    if: ${{ needs.changed-files.outputs.any_modified }}
     strategy:
       fail-fast: false
       matrix:
@@ -17,6 +39,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/k8s-compatibility-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: ${{ matrix.test_make_target }}
           operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
@@ -24,12 +48,16 @@ jobs:
   istio-upgrade-integration-test:
     name: Istio upgrade integration test
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: ${{ needs.changed-files.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - uses: ./.github/actions/upgrade-integration-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
           target_branch: ${{ github.base_ref }}
@@ -37,6 +65,8 @@ jobs:
   istio-integration-test:
     name: Istio integration test
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: ${{ needs.changed-files.outputs.any_modified }}
     strategy:
       fail-fast: false
       matrix:
@@ -47,6 +77,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - uses: ./.github/actions/integration-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: ${{ matrix.test_make_target }}
           operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
@@ -56,12 +88,16 @@ jobs:
   istio-integration-test-evaluation:
     name: Istio integration test evaluation
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: ${{ needs.changed-files.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - uses: ./.github/actions/integration-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: "evaluation-integration-test"
           operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"

--- a/.github/workflows/pull-integration.yaml
+++ b/.github/workflows/pull-integration.yaml
@@ -6,10 +6,32 @@ name: Pull Request integration tests
 on:
   workflow_call:
 
-jobs: 
+jobs:
+  changed-files:
+    outputs:
+      any_modified: ${{ steps.changed-files.outputs.any_modified }}
+    name: Check whether integration tests should run based on the changed files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed-files
+        with:
+          files_ignore: |
+            docs/**
+            **/*.md
+            tests/performance/**
+            OWNERS
+            CODEOWNERS
+            sec-scanners-config.yaml
+            .reuse/**
+            external-images.yaml
+
   k8s-compatibility-test:
     name: Kubernetes version compatibility test
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: needs.changed-files.outputs.any_modified == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -18,6 +40,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/load-manager-image
       - uses: ./.github/actions/k8s-compatibility-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: ${{ matrix.test_make_target }}
           operator-image-name: "istio-manager:PR-${{github.event.number}}"
@@ -25,12 +49,16 @@ jobs:
   istio-upgrade-integration-test:
     name: Istio upgrade integration test
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: needs.changed-files.outputs.any_modified == 'true'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/load-manager-image
       - uses: ./.github/actions/upgrade-integration-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           operator-image-name: "istio-manager:PR-${{github.event.number}}"
           target_branch: ${{ github.base_ref }}
@@ -38,6 +66,8 @@ jobs:
   istio-integration-test:
     name: Istio integration test
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: needs.changed-files.outputs.any_modified == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +78,8 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/load-manager-image
       - uses: ./.github/actions/integration-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: ${{ matrix.test_make_target }}
           operator-image-name: "istio-manager:PR-${{github.event.number}}"
@@ -57,12 +89,16 @@ jobs:
   istio-integration-test-evaluation:
     name: Istio integration test evaluation
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: needs.changed-files.outputs.any_modified == 'true'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/load-manager-image
       - uses: ./.github/actions/integration-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: "evaluation-integration-test"
           operator-image-name: "istio-manager:PR-${{github.event.number}}"

--- a/.github/workflows/pull-request-release.yaml
+++ b/.github/workflows/pull-request-release.yaml
@@ -5,32 +5,9 @@ on:
     branches:
       - 'release-**'
 jobs:
-  check-build-image:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether build image should run
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            .reuse/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
   build-image:
     name: Build manager image
-    needs: [check-build-image]
-    if: ${{ needs.check-build-image.outputs.check == 'true' }}
+    if: github.event.pull_request.draft == false
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: istio-manager
@@ -39,114 +16,44 @@ jobs:
       build-args: |
         VERSION=PR-${{ github.event.number }}
 
-  check-unit-test:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether unit test & lint should run based on the changed files
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            .reuse/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-unit-test:
+  unit-tests:
     name: Dispatch unit test
-    needs: [check-unit-test]
     uses: ./.github/workflows/pull-unit-lint.yaml
-    if: ${{ needs.check-unit-test.outputs.check == 'true' }}
+    if: github.event.pull_request.draft == false
     secrets: inherit
 
-  check-integration:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether integration tests should run based on the changed files
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            .reuse/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-integration:
+  integration-tests:
     name: Dispatch integration tests
-    needs: [check-integration,build-image]
+    needs: [build-image]
     uses: ./.github/workflows/pull-integration-release.yaml
-    if: ${{ needs.check-integration.outputs.check == 'true' }}
-    secrets: inherit
-  dispatch-integration-gardener:
-    name: Dispatch Gardener integration tests
-    needs: [check-integration,build-image]
-    uses: ./.github/workflows/pull-integration-gardener-release.yaml
-    if: ${{ needs.check-integration.outputs.check == 'true' }}
-    secrets: inherit
-
-  check-ui:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether UI tests should run based on the changed files
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files: |
-            config/ui-extensions/**
-            config/crd/**
-            tests/ui/**
-            .github/workflows/ui-tests.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-ui:
-    name: Dispatch UI tests
-    needs: [check-ui,build-image]
-    uses: ./.github/workflows/ui-tests.yaml
-    if: ${{ needs.check-ui.outputs.check == 'true' }}
     secrets: inherit
 
-  check-verify-pins:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether to run verify-commit-pins
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+  integration-tests-gardener:
+    name: Dispatch Gardener integration tests
+    needs: [build-image]
+    uses: ./.github/workflows/pull-integration-gardener-release.yaml
+    if: github.event.pull_request.draft == false
+    secrets: inherit
+
+  ui-tests:
+    name: Dispatch UI tests
+    needs: [build-image]
+    uses: ./.github/workflows/ui-tests.yaml
+    if: github.event.pull_request.draft == false
+    secrets: inherit
+
+  verify-pins:
+    name: Dispatch verify-commit-pins
+    uses: ./.github/workflows/verify-commit-pins.yaml
+    if: github.event.pull_request.draft == false
+    secrets: inherit
+
+  pull-request-status:
+    needs: [ build-image, unit-tests, integration-tests, integration-tests-gardener, ui-tests, verify-pins ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files: |
-            .github/workflows/**
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-verify-pins:
-    name: Dispatch verify-commit-pins
-    needs: [check-verify-pins]
-    uses: ./.github/workflows/verify-commit-pins.yaml
-    if: ${{ needs.check-verify-pins.outputs.check == 'true' }}
-    secrets: inherit
+      - if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -21,139 +21,48 @@ jobs:
         env:
           PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PULL_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-  check-build-image:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether build image should run
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-             docs/**
-             **/*.md
-             tests/performance/**
-             OWNERS
-             CODEOWNERS
-             .reuse/**
-             external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
 
   build-image:
     name: Build manager image
     runs-on: ubuntu-latest
-    needs: [check-build-image]
-    if: ${{ needs.check-build-image.outputs.check== 'true' }}
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-manager-image
         with:
           operator-image-name: "istio-manager:PR-${{github.event.number}}"
 
-  check-unit-test:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether unit test & lint should run based on the changed files
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            sec-scanners-config.yaml
-            .reuse/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-unit-test:
+  unit-tests:
     name: Dispatch unit test
-    needs: [check-unit-test]
     uses: ./.github/workflows/pull-unit-lint.yaml
-    if: ${{ needs.check-unit-test.outputs.check == 'true' }}
+    if: github.event.pull_request.draft == false
     secrets: inherit
 
-  check-integration:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether integration tests should run based on the changed files
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            sec-scanners-config.yaml
-            .reuse/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-integration:
+  integration-tests:
     name: Dispatch integration tests
-    needs: [check-integration,build-image]
+    needs: [build-image]
     uses: ./.github/workflows/pull-integration.yaml
-    if: ${{ needs.check-integration.outputs.check == 'true' }}
-    secrets: inherit
-
-  check-ui:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether UI tests should run based on the changed files
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files: |
-            config/ui-extensions/**
-            config/crd/**
-            tests/ui/**
-            .github/workflows/ui-tests.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-ui:
-    name: Dispatch UI tests
-    needs: [check-ui,build-image]
-    uses: ./.github/workflows/ui-tests.yaml
-    if: ${{ needs.check-ui.outputs.check == 'true' }}
     secrets: inherit
 
-  check-verify-pins:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether to run verify-commit-pins
+  ui-tests:
+    name: Dispatch UI tests
+    needs: [build-image]
+    uses: ./.github/workflows/ui-tests.yaml
+    if: github.event.pull_request.draft == false
+    secrets: inherit
+
+  verify-pins:
+    name: Dispatch verify-commit-pins
+    uses: ./.github/workflows/verify-commit-pins.yaml
+    if: github.event.pull_request.draft == false
+    secrets: inherit
+
+  pull-request-status:
+    needs: [ build-image, unit-tests, integration-tests, ui-tests, verify-pins ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files: |
-            .github/workflows/**
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-verify-pins:
-    name: Dispatch verify-commit-pins
-    needs: [check-verify-pins]
-    uses: ./.github/workflows/verify-commit-pins.yaml
-    if: ${{ needs.check-verify-pins.outputs.check == 'true' }}
-    secrets: inherit
+      - if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/pull-unit-lint.yaml
+++ b/.github/workflows/pull-unit-lint.yaml
@@ -6,9 +6,31 @@ on:
   workflow_call:
 
 jobs:
+  changed-files:
+    outputs:
+      any_modified: ${{ steps.changed-files.outputs.any_modified }}
+    name: Check whether unit test & lint should run based on the changed files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed-files
+        with:
+          files_ignore: |
+            docs/**
+            **/*.md
+            tests/performance/**
+            OWNERS
+            CODEOWNERS
+            sec-scanners-config.yaml
+            .reuse/**
+            external-images.yaml
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: ${{ needs.changed-files.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -24,12 +46,16 @@ jobs:
   run-unit-tests:
     name: Run unit tests
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: ${{ needs.changed-files.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
       - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PULL_PULL_SHA=${{ github.event.pull_request.head.sha}} \
           PULL_BASE_SHA=${{ github.event.pull_request.base.sha}} \
@@ -38,6 +64,8 @@ jobs:
 
   run-unit-tests-experimental:
     name: Run unit tests with experimental build tag
+    if: ${{ needs.changed-files.outputs.any_modified }}
+    needs: [ changed-files ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,4 +73,6 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make test-experimental-tag

--- a/.github/workflows/ui-tests.yaml
+++ b/.github/workflows/ui-tests.yaml
@@ -11,11 +11,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed-files
+        with:
+          files: |
+            config/ui-extensions/**
+            config/crd/**
+            tests/ui/**
+            .github/workflows/ui-tests.yaml
       - uses: ./.github/actions/load-manager-image
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - name: Run tests
+      - name: Tests
+        if: ${{ steps.changed-files.outputs.any_modified }}
         run: |
           sudo echo "127.0.0.1 local.kyma.dev" | sudo tee -a /etc/hosts
           wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | sudo bash

--- a/.github/workflows/verify-commit-pins.yaml
+++ b/.github/workflows/verify-commit-pins.yaml
@@ -9,7 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed-files
+        with:
+          files: |
+            .github/workflows/**
       - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@3c16e895bb662b4d7e284f032cbe8835a57773cc # 3.0.11
+        if: ${{ steps.changed-files.outputs.any_modified }}
         with:
           # We only want to allow official Github Actions
           allowlist: |


### PR DESCRIPTION
/kind chore
/area ci

Consolidate job statuses in PRs into one, as in api-gateway repo
Add GITHUB_TOKEN usage in workflows that use make
