### PR TITLE
bug: always run status action

### DIFF
--- a/.github/workflows/pull-request-release.yaml
+++ b/.github/workflows/pull-request-release.yaml
@@ -52,6 +52,7 @@ jobs:
   pull-request-status:
     needs: [ build-image, unit-tests, integration-tests, integration-tests-gardener, ui-tests, verify-pins ]
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - if: ${{ !(contains(needs.*.result, 'failure')) }}
         run: exit 0

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -61,6 +61,7 @@ jobs:
   pull-request-status:
     needs: [ build-image, unit-tests, integration-tests, ui-tests, verify-pins ]
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - if: ${{ !(contains(needs.*.result, 'failure')) }}
         run: exit 0


### PR DESCRIPTION
/kind chore
/area ci

Seems that when previous job fails, status job gets skipped, resulting in letting PR merge. Try to always run the job regardless the result of previous dependant jobs.
