### PR TITLE
chore: separate main and release images

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Check security-scanner config
         shell: bash
         run: |
-          if [[ $( yq eval ".protecode[0]" sec-scanners-config.yaml ) == "europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{ github.event.inputs.name }}" ]]; then
+          if [[ $( yq eval ".protecode[0]" sec-scanners-config.yaml ) == "europe-docker.pkg.dev/kyma-project/prod/istio/releases/istio-manager:${{ github.event.inputs.name }}" ]]; then
             exit 0
           else
             echo "Error: istio-manager image tag in sec-scanners-config doesn't match release ${{ github.event.inputs.name }}"

--- a/.github/workflows/main-integration.yaml
+++ b/.github/workflows/main-integration.yaml
@@ -43,7 +43,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false && needs.filter-changes.outputs.check == 'true' }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
-      name: istio-manager
+      name: istio/main/istio-manager
       dockerfile: Dockerfile
       context: .
       build-args: |
@@ -56,7 +56,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false && needs.filter-changes.outputs.check == 'true' }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
-      name: istio-manager
+      name: istio/main/istio-manager
       dockerfile: Dockerfile
       context: .
       build-args: |
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-istio-integration-test
+      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:${{github.sha}}" gardener-istio-integration-test
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -114,7 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: ${{ matrix.test_make_target }}
-          operator-image-name: "europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}"
+          operator-image-name: "europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:${{github.sha}}"
           servers-memory: "16"
           agents: 2
 
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-istio-integration-test
+      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:${{github.sha}}" gardener-istio-integration-test
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-aws-integration-test
+      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:${{github.sha}}" gardener-aws-integration-test
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-gcp-integration-test
+      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:${{github.sha}}" gardener-gcp-integration-test
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -235,7 +235,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{github.sha}}" gardener-istio-integration-test
+      - run: make IMG="europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:${{github.sha}}" gardener-istio-integration-test
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/performance-test.yaml
+++ b/.github/workflows/performance-test.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - run: |
-          make IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${{ github.sha }}" gardener-perf-test
+          make IMG="europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:${{ github.sha }}" gardener-perf-test
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-integration-gardener-release.yaml
+++ b/.github/workflows/pull-integration-gardener-release.yaml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMG: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          IMG: "europe-docker.pkg.dev/kyma-project/dev/istio/pr/istio-manager:PR-${{github.event.number}}"
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "goat"
@@ -84,7 +84,7 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMG: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          IMG: "europe-docker.pkg.dev/kyma-project/dev/istio/pr/istio-manager:PR-${{github.event.number}}"
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "aws-gardener-access"
@@ -118,7 +118,7 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMG: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          IMG: "europe-docker.pkg.dev/kyma-project/dev/istio/pr/istio-manager:PR-${{github.event.number}}"
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "goat"

--- a/.github/workflows/pull-integration-release.yaml
+++ b/.github/workflows/pull-integration-release.yaml
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: ${{ matrix.test_make_target }}
-          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio/pr/istio-manager:PR-${{github.event.number}}"
 
   istio-upgrade-integration-test:
     name: Istio upgrade integration test
@@ -59,7 +59,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio/pr/istio-manager:PR-${{github.event.number}}"
           target_branch: ${{ github.base_ref }}
 
   istio-integration-test:
@@ -81,7 +81,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: ${{ matrix.test_make_target }}
-          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio/pr/istio-manager:PR-${{github.event.number}}"
           servers-memory: "16"
           agents: 2
 
@@ -100,6 +100,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: "evaluation-integration-test"
-          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio-manager:PR-${{github.event.number}}"
+          operator-image-name: "europe-docker.pkg.dev/kyma-project/dev/istio/pr/istio-manager:PR-${{github.event.number}}"
           servers-memory: "4"
           agents: 0

--- a/.github/workflows/pull-request-release.yaml
+++ b/.github/workflows/pull-request-release.yaml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
-      name: istio-manager
+      name: istio/pr/istio-manager
       dockerfile: Dockerfile
       context: .
       build-args: |

--- a/.github/workflows/ui-tests-periodic.yaml
+++ b/.github/workflows/ui-tests-periodic.yaml
@@ -31,8 +31,8 @@ jobs:
         run: |
           sudo echo "127.0.0.1 local.kyma.dev" | sudo tee -a /etc/hosts
           wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | sudo bash
-          docker pull europe-docker.pkg.dev/kyma-project/prod/istio-manager:"${{github.sha}}"
-          IMG=europe-docker.pkg.dev/kyma-project/prod/istio-manager:"${{github.sha}}" ./tests/ui/scripts/k3d-ci-kyma-dashboard-integration.sh stage
+          docker pull europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:"${{github.sha}}"
+          IMG=europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:"${{github.sha}}" ./tests/ui/scripts/k3d-ci-kyma-dashboard-integration.sh stage
       - uses: actions/upload-artifact@v4
         if: always()
         name: Export Cypress output

--- a/.github/workflows/update-sec-scanner.yaml
+++ b/.github/workflows/update-sec-scanner.yaml
@@ -17,7 +17,7 @@ jobs:
           IMAGE_TAG_REGEXP: v[0-9]{8}-[a-f0-9]{6,9}
         run: |
           # grab latest tag from sorted list of tags for given TAG_REGEXP
-          IMAGE_TAG=$(skopeo list-tags docker://europe-docker.pkg.dev/kyma-project/prod/istio-manager | jq -r ".Tags[] | select(.| test(\"$IMAGE_TAG_REGEXP\"))" | sort | tail -1)
+          IMAGE_TAG=$(skopeo list-tags docker://europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager | jq -r ".Tags[] | select(.| test(\"$IMAGE_TAG_REGEXP\"))" | sort | tail -1)
           if [[ -z $IMAGE_TAG ]]; then
             echo Fetched image tag is empty, most likely your IMAGE_TAG_REGEXP is incorrect
             exit 1
@@ -34,7 +34,7 @@ jobs:
           git fetch origin
           git checkout -f autobump/sec-scanners-config
           git reset --hard origin/main
-          sed -i "s/europe-docker\.pkg\.dev\/kyma-project\/prod\/istio-manager\:.*/europe-docker\.pkg\.dev\/kyma-project\/prod\/istio-manager\:$IMAGE_TAG/" sec-scanners-config.yaml
+          sed -i "s/europe-docker\.pkg\.dev\/kyma-project\/prod\/istio\/main\/istio-manager\:.*/europe-docker\.pkg\.dev\/kyma-project\/prod\/istio\/main\/istio-manager\:$IMAGE_TAG/" sec-scanners-config.yaml
           git add .
           if git diff-index --quiet HEAD; then
             echo "No changes detected - no action required"

--- a/scripts/publish_assets.sh
+++ b/scripts/publish_assets.sh
@@ -13,7 +13,7 @@ RELEASE_ID=$2
 REPOSITORY=${REPOSITORY:-kyma-project/istio}
 GITHUB_URL=https://uploads.github.com/repos/${REPOSITORY}
 GITHUB_AUTH_HEADER="Authorization: Bearer ${GITHUB_TOKEN}"
-IMG="europe-docker.pkg.dev/kyma-project/prod/istio-manager:${RELEASE_TAG}"
+IMG="europe-docker.pkg.dev/kyma-project/prod/istio/releases/istio-manager:${RELEASE_TAG}"
 VERSION="${RELEASE_TAG}"
 
 IMG="${IMG}" VERSION="${VERSION}" make generate-manifests


### PR DESCRIPTION
/kind chore
/area ci

Separate images that we run on main/releases/pr in order to keep better isolation between the artifacts to allow introducing registry automations.

#925 