### PR TITLE
bug: add refs fetch in update-sec-scanner.yaml

### DIFF
--- a/.github/workflows/update-sec-scanner.yaml
+++ b/.github/workflows/update-sec-scanner.yaml
@@ -20,6 +20,8 @@ jobs:
           IMAGE_TAG_REGEXP: v[0-9]{8}-[a-f0-9]{6,9}
         run: |
           # grab latest image associated with a commit in git history
+          git fetch origin
+          git checkout main
           while read -r SHA; do
             if skopeo inspect "docker://$IMAGE:$SHA" &> /dev/null; then
               echo "found image: $IMAGE:$SHA"


### PR DESCRIPTION
/kind bug
/area ci

add fetching origin refs, because apparently there are no commit history.

#925 