### PR TITLE
bug: add refs fetch in update-sec-scanner.yaml

### DIFF
--- a/.github/workflows/update-sec-scanner.yaml
+++ b/.github/workflows/update-sec-scanner.yaml
@@ -14,16 +14,16 @@ jobs:
       IMAGE: europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: get latest tag
         id: latest-sha
         env:
           IMAGE_TAG_REGEXP: v[0-9]{8}-[a-f0-9]{6,9}
         run: |
           # grab latest image associated with a commit in git history
-          git fetch origin
-          git checkout main
           while read -r SHA; do
-            if skopeo inspect "docker://$IMAGE:$SHA" &> /dev/null; then
+            if skopeo inspect "docker://$IMAGE:$SHA"; then
               echo "found image: $IMAGE:$SHA"
               echo "image-tag=$SHA" >> "$GITHUB_OUTPUT"
               exit 0


### PR DESCRIPTION
/kind bug
/area ci

add fetching all refs, because apparently there are no commit history by default.

#925 