### PR TITLE
chore: change default token in checkout action

### DIFF
--- a/.github/workflows/update-sec-scanner.yaml
+++ b/.github/workflows/update-sec-scanner.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GOAT_BOT_REPO_ACCESS }}
       - name: get latest tag
         id: latest-sha
         env:


### PR DESCRIPTION
/kind chore
/area ci

token value in actions/checkout action defaults to `github.token`. Even if I set GITHUB_TOKEN env, it will use default github actions account to interact with repo using git. Use custom token.

#925 