### PR TITLE
fix: Revert enabling prometheusMerge feature

### DIFF
--- a/internal/istiooperator/istio-operator-light.yaml
+++ b/internal/istiooperator/istio-operator-light.yaml
@@ -143,7 +143,7 @@ spec:
       tracing: []
       metrics:
       - prometheus
-    enablePrometheusMerge: true
+    enablePrometheusMerge: false
     enableTracing: false
     extensionProviders:
     - name: kyma-traces

--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -168,7 +168,7 @@ spec:
       tracing: []
       metrics:
       - prometheus
-    enablePrometheusMerge: true
+    enablePrometheusMerge: false
     enableTracing: false
     extensionProviders:
     - name: kyma-traces


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The enablement of the prometheusMerge feature was tested thoroughly with the Kyma telemetry feature and decided that on the current landscapes will not introduce a breaking change. Unfortunately, the analysis missed the fact that users can run a prometheus with a sidecar which is having a scrape loop for pod-based prometheus annotations, which scrapes istiofied workload using https, see https://github.com/kyma-project/examples/tree/main/prometheus for an example. Indeed, this scenario is a breaking change as after enabling the feature, the prometheus will call the new istio endpoint still with https, but the endpoint does not support TLS anymore.

This PR is reverting the change, and the feature will get introduced properly by having a configuration option which is disabled by default in ticket https://github.com/kyma-project/istio/issues/1185.

Changes proposed in this pull request:

- Revert of enabling the prometheusMerge feature introduced at https://github.com/kyma-project/istio/pull/1114

**Pre-Merge Checklist**

- [x] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/istio/pull/1114
https://github.com/kyma-project/telemetry-manager/issues/1468
https://github.com/kyma-project/istio/issues/1185