### PR TITLE
backport fix: Revert enabling prometheusMerge feature

### DIFF
--- a/internal/istiooperator/istio-operator-light.yaml
+++ b/internal/istiooperator/istio-operator-light.yaml
@@ -143,7 +143,7 @@ spec:
       tracing: []
       metrics:
       - prometheus
-    enablePrometheusMerge: true
+    enablePrometheusMerge: false
     enableTracing: false
     extensionProviders:
     - name: kyma-traces

--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -168,7 +168,7 @@ spec:
       tracing: []
       metrics:
       - prometheus
-    enablePrometheusMerge: true
+    enablePrometheusMerge: false
     enableTracing: false
     extensionProviders:
     - name: kyma-traces


### PR DESCRIPTION
(cherry picked from commit b3a365007360dfb8169cdcf3b35efc921986fd8a)

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- backport of https://github.com/kyma-project/istio/pull/1184 to release 1.11

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
