### PR TITLE
Bump slack action in the failed workflow notification

### DIFF
--- a/.github/actions/slack-notification-failed-workflow/action.yaml
+++ b/.github/actions/slack-notification-failed-workflow/action.yaml
@@ -12,7 +12,7 @@ runs:
     - name: Notify
       uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
       with:
-        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook: ${{ inputs.SLACK_WEBHOOK_URL }}
         webhook-type: webhook-trigger
         payload-templated: true
         payload: |

--- a/.github/actions/slack-notification-failed-workflow/action.yaml
+++ b/.github/actions/slack-notification-failed-workflow/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Notify
-      uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+      uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
         webhook-type: webhook-trigger

--- a/.github/workflows/main-integration.yaml
+++ b/.github/workflows/main-integration.yaml
@@ -30,7 +30,6 @@ jobs:
             OWNERS
             CODEOWNERS
             sec-scanners-config.yaml
-            .github/**
             .**
             external-images.yaml
       - name: List all changed files


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump slack action in the failed workflow notification
- Fix reference to secrets instead of inputs in the slack notification action
- Drop .github from pathignore in the main push workflow