### PR TITLE
feat: egress e2e test

### DIFF
--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
+        test_make_target: [ "test-e2e", "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
+        test_make_target: [ "test-e2e", "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/post-main-workflow.yaml
+++ b/.github/workflows/post-main-workflow.yaml
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
+        test_make_target: [ "test-e2e", "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
+        test_make_target: [ "test-e2e", "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,11 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=2m KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT=2m KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(shell go list ./... | grep -v /tests/integration | grep -v /tests/performance-grpc) -coverprofile cover.out
+	KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=2m KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT=2m KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(shell go list ./... | grep -v /tests/integration | grep -v /tests/performance-grpc | grep -v /tests/e2e) -coverprofile cover.out
 
 .PHONY: test-experimental-tag
 test-experimental-tag: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=2m KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT=2m KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -tags experimental $(shell go list ./... | grep -v /tests/integration | grep -v /tests/performance-grpc) -coverprofile cover.out
+	KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=2m KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT=2m KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -tags experimental $(shell go list ./... | grep -v /tests/integration | grep -v /tests/performance-grpc | grep -v /tests/e2e) -coverprofile cover.out
 
 ##@ Build
 
@@ -182,6 +182,10 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
+.PHONY: gotestsum
+gotestsum:
+	test -s $(LOCALBIN)/gotestsum || GOBIN=$(LOCALBIN) go install gotest.tools/gotestsum@latest
+
 .PHONY: yq
 yq: $(YQUERY) ## Download yq locally if necessary.
 $(YQUERY): $(LOCALBIN)
@@ -192,6 +196,9 @@ envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
+.PHONY: test-e2e
+test-e2e: gotestsum
+	$(LOCALBIN)/gotestsum --format "testname" -- -run '^TestE2E.*' ./tests/e2e/...
 ##@ Module
 
 .PHONY: module-image

--- a/pkg/lib/gatherer/gatherer.go
+++ b/pkg/lib/gatherer/gatherer.go
@@ -155,7 +155,7 @@ func VerifyIstioPodsVersion(ctx context.Context, kubeClient client.Client, istio
 
 func getImageVersion(image string) (*semver.Version, error) {
 	matches := reference.ReferenceRegexp.FindStringSubmatch(image)
-	if matches == nil || len(matches) < 3 {
+	if len(matches) < 3 {
 		return &NoVersion, fmt.Errorf("Unable to parse container image reference: %s", image)
 	}
 	version, err := semver.NewVersion(matches[2])

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,50 +1,50 @@
-# End-to-end tests
+# End-to-End Tests
 
-This directory contains definitions and implementations of end-to-end tests for istio operator.
-These tests are for testing the connectivity of istio components to external services, implementing user scenarios.
+This directory contains definitions and implementations of end-to-end tests for Istio Operator.
+These tests verify the connectivity of Istio components to external services, implementing user scenarios.
 
-## Running end-to-end tests
+## Running End-to-End Tests
 
-E2E tests run against cluster that is set up as active in your `KUBECONFIG` file. If you want to change the target,
+E2E tests run against a cluster that is set up as active in your `KUBECONFIG` file. If you want to change the target,
 export an environment vairable `KUBECONFIG` to specific kubeconfig file. Make sure you have admin permission on a
 cluster.
 
-To run the E2E tests, use `make test-e2e` command in project root directory.
+To run the E2E tests, use the `make test-e2e` command in the project's root directory.
 You can also use `go test -run '^TestE2E.*' ./tests/e2e/...`directly, if you don't want to use make.
 
-## Writing end-to-end tests
+## Writing End-to-End Tests
 
 If you want to add another E2E test, there are several topics to follow.
 
 Tests use lightweight testing framework included in the Go language.
 For more information and reference, read the official Testing package documentation: https://pkg.go.dev/testing.
 
-The tests are separate functions that expect that test cluster is configured with Istio manager installed without Istio CR applied.
-Each function has to configure the cluster in runtime and then clean up the cluster back to initial state, removing all resources that were created.
+The tests are separate functions that expect that the test cluster is configured with Istio manager installed without the Istio CR applied.
+Each function has to configure the cluster in runtime and then clean up the cluster back to its initial state, removing all created resources.
 
-For cleanup tasks, use default `t.Cleanup()` function from Testing package.
+For cleanup tasks, use the default `t.Cleanup()` function from the `Testing` package.
 
-For helper functions use `t.Helper()` call. Each helper function should accept `t *testing.T` as argument.
+For helper functions, use the `t.Helper()` call. Each helper function should accept `t *testing.T` as an argument.
 Returning errors in this case is not really necessary. Just use `t.Error()` or `t.Fatal()` like with usual tests.
 
 Avoid using global variables unless necessary. Do not import variables from other test packages, unless the external
 package is a library.
 
-For logging additional information, use default `t.Log()` and `t.Logf()` functions from Testing package.
+For logging additional information, use the default `t.Log()` and `t.Logf()` functions from the `Testing` package.
 
-Each of the test should be put in its own package. Keep the fixtures under `testdata` directory in the same package.
+Each of the tests should be put in its own package. Keep the fixtures under the `testdata` directory in the same package.
 
-Put libraries used in tests under `pkg` directory, just as in standard Go project scheme.
+Put libraries used in tests under the `pkg` directory, just as in the standard Go project scheme.
 
-Function body does not follow a strict methodology. Just keep it simple. Usually they are written as procedural functions.
-If you need to implement more advanced logic, remember to not leak the implementation outside the package/function.
+The function's body does not follow a strict methodology. Just keep it simple. Usually, they are written as procedural functions.
+If you need to implement more advanced logic, remember not to leak the implementation outside the package/function.
 
-Start name of each function with prefix `TestE2E`.
-When running `go test`, we set up pattern for running tests that only start with this prefix.
+Start each function's name with the prefix `TestE2E`.
+When running `go test`, we set up a pattern for running tests that only start with this prefix.
 
 When you want to conditionally run specific test, use environment variables.
 Those environment variables must be set in the environment before running `go test`. Do not set the variable in the test file.
-For example, when the test should run only on gardener, add the simple if statement at the beginning of your test function:
+For example, when the test should run only on Gardener, add the simple `if` statement at the beginning of your test function:
 ```go
 if os.Getenv("VARIABLE") == "true" {
 	// for better visibility, add message in the function call
@@ -52,5 +52,5 @@ if os.Getenv("VARIABLE") == "true" {
 }
 ```
 
-When you need to test multiple options in single configuration of a cluster, consider using table-driven tests.
+When you need to test multiple options in a single configuration of a cluster, consider using table-driven tests.
 For more information, follow official Go documentation: https://go.dev/wiki/TableDrivenTests.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,56 @@
+# End-to-end tests
+
+This directory contains definitions and implementations of end-to-end tests for istio operator.
+These tests are for testing the connectivity of istio components to external services, implementing user scenarios.
+
+## Running end-to-end tests
+
+E2E tests run against cluster that is set up as active in your `KUBECONFIG` file. If you want to change the target,
+export an environment vairable `KUBECONFIG` to specific kubeconfig file. Make sure you have admin permission on a
+cluster.
+
+To run the E2E tests, use `make test-e2e` command in project root directory.
+You can also use `go test -run '^TestE2E.*' ./tests/e2e/...`directly, if you don't want to use make.
+
+## Writing end-to-end tests
+
+If you want to add another E2E test, there are several topics to follow.
+
+Tests use lightweight testing framework included in the Go language.
+For more information and reference, read the official Testing package documentation: https://pkg.go.dev/testing.
+
+The tests are separate functions that expect that test cluster is configured with Istio manager installed without Istio CR applied.
+Each function has to configure the cluster in runtime and then clean up the cluster back to initial state, removing all resources that were created.
+
+For cleanup tasks, use default `t.Cleanup()` function from Testing package.
+
+For helper functions use `t.Helper()` call. Each helper function should accept `t *testing.T` as argument.
+Returning errors in this case is not really necessary. Just use `t.Error()` or `t.Fatal()` like with usual tests.
+
+Avoid using global variables unless necessary. Do not import variables from other test packages, unless the external
+package is a library.
+
+For logging additional information, use default `t.Log()` and `t.Logf()` functions from Testing package.
+
+Each of the test should be put in its own package. Keep the fixtures under `testdata` directory in the same package.
+
+Put libraries used in tests under `pkg` directory, just as in standard Go project scheme.
+
+Function body does not follow a strict methodology. Just keep it simple. Usually they are written as procedural functions.
+If you need to implement more advanced logic, remember to not leak the implementation outside the package/function.
+
+Start name of each function with prefix `TestE2E`.
+When running `go test`, we set up pattern for running tests that only start with this prefix.
+
+When you want to conditionally run specific test, use environment variables.
+Those environment variables must be set in the environment before running `go test`. Do not set the variable in the test file.
+For example, when the test should run only on gardener, add the simple if statement at the beginning of your test function:
+```go
+if os.Getenv("VARIABLE") == "true" {
+	// for better visibility, add message in the function call
+	t.Skip()
+}
+```
+
+When you need to test multiple options in single configuration of a cluster, consider using table-driven tests.
+For more information, follow official Go documentation: https://go.dev/wiki/TableDrivenTests.

--- a/tests/e2e/egress/egress_test.go
+++ b/tests/e2e/egress/egress_test.go
@@ -1,0 +1,439 @@
+package egress_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	operatorv1alpha2 "github.com/kyma-project/istio/operator/api/v1alpha2"
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/api/telemetry/v1alpha1"
+	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
+	istiotelemetryv1 "istio.io/client-go/pkg/apis/telemetry/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+var (
+	defaultWaitBackoff = wait.Backoff{
+		Cap:      3 * time.Minute,
+		Duration: time.Second,
+		Steps:    10,
+		Factor:   1.5,
+	}
+)
+
+// TestE2EEgressConnectivity tests the connectivity of istio installed through istio-module.
+// This test expects that istio-module is installed and access to cluster is set up via KUBECONFIG env.
+func TestE2EEgressConnectivity(t *testing.T) {
+	// initialization
+	ctx := context.Background()
+	cfg := config.GetConfigOrDie()
+	c, err := initK8sClient(cfg)
+	if err != nil {
+		t.Fatalf("failed to init cluster client: %v", err)
+	}
+	setupIstio(ctx, c, t)
+
+	// initialize testcases
+	// note: test might fail randomly from random downtime to httpbin.org with error Connection reset by peer.
+	// This is a flake, and we need to think how to resolve that eventually.
+	tc := []struct {
+		name                 string
+		cmd                  []string
+		expectError          bool
+		applyNetworkPolicy   bool
+		applyEgressConfig    bool
+		enableIstioInjection bool
+	}{
+		{
+			name:                 "connection to httpbin service is OK when egress is deployed",
+			cmd:                  []string{"curl", "-sSL", "-m", "10", "https://httpbin.org/headers"},
+			enableIstioInjection: true,
+			applyEgressConfig:    true,
+			expectError:          false,
+		},
+		{
+			name:               "connection to httpbin service is refused when NetworkPolicy is applied",
+			cmd:                []string{"curl", "-sSL", "-m", "10", "https://httpbin.org/headers"},
+			applyNetworkPolicy: true,
+			// sidecar init fails when NP is applied. When uncommented, the test will pass despite confirming manually
+			// that connection is refused with NP
+			enableIstioInjection: true,
+			expectError:          true,
+		},
+		{
+			name:                 "connection to httpbin service is OK when NetworkPolicy is applied and egress is configured",
+			cmd:                  []string{"curl", "-sSL", "-m", "10", "https://httpbin.org/headers"},
+			enableIstioInjection: true,
+			applyEgressConfig:    true,
+			applyNetworkPolicy:   true,
+			expectError:          false,
+		},
+		{
+			name:                 "connection to kyma-project is refused when NetworkPolicy is applied and egress is configured",
+			cmd:                  []string{"curl", "-sSL", "-m", "10", "https://kyma-project.io"},
+			enableIstioInjection: true,
+			applyEgressConfig:    true,
+			applyNetworkPolicy:   true,
+			expectError:          true,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := createTestNamespace(ctx, c, tt.enableIstioInjection, t)
+			if tt.applyEgressConfig {
+				err := applyEgressConfig(ctx, c, ns)
+				if err != nil {
+					t.Errorf("failed to create egress resources: %v", err)
+				}
+			}
+			if tt.applyNetworkPolicy {
+				applyNetworPolicy(ctx, c, t, ns)
+			}
+
+			out, err := runCurlInPod(ctx, cfg, ns, tt.cmd)
+			if err != nil && !tt.expectError {
+				t.Errorf("got an error but shouldn't have: %v", err)
+			}
+			if err == nil && tt.expectError {
+				t.Error("didn't get an error but expected one")
+			}
+
+			t.Log(string(out))
+		})
+	}
+}
+
+func setupIstio(ctx context.Context, c client.Client, t *testing.T) {
+	// this function is a helper
+	t.Helper()
+	// configure cluster before testcases
+	// init istio CR and wait for installation
+	istioCR := operatorv1alpha2.Istio{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istio-operator",
+			Namespace: "kyma-system",
+		},
+		Spec: operatorv1alpha2.IstioSpec{
+			Components: &operatorv1alpha2.Components{
+				EgressGateway: &operatorv1alpha2.EgressGateway{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+	}
+	t.Cleanup(func() {
+		_ = c.Delete(ctx, &istioCR)
+		_ = wait.ExponentialBackoffWithContext(ctx, defaultWaitBackoff, func(ctx context.Context) (bool, error) {
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}}
+			err := c.Get(ctx, client.ObjectKeyFromObject(&ns), &ns)
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, nil
+		})
+	})
+
+	if err := c.Create(ctx, &istioCR); err != nil {
+		t.Fatalf("failed to create Istio CR: %v", err)
+	}
+	// wait for resource as function
+	err := wait.ExponentialBackoffWithContext(ctx, defaultWaitBackoff, func(ctx context.Context) (bool, error) {
+		err := c.Get(ctx, client.ObjectKeyFromObject(&istioCR), &istioCR)
+		if err != nil {
+			return false, err
+		}
+		state := string(istioCR.Status.State)
+		if state == "Ready" {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logsCR := istiotelemetryv1.Telemetry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mesh-default",
+			Namespace: "istio-system",
+		},
+		Spec: v1alpha1.Telemetry{
+			AccessLogging: []*v1alpha1.AccessLogging{
+				{
+					Providers: []*v1alpha1.ProviderRef{
+						{
+							Name: "envoy",
+						},
+					},
+				},
+			},
+		},
+	}
+	t.Cleanup(func() {
+		_ = c.Delete(ctx, &logsCR)
+	})
+	if err := c.Create(ctx, &logsCR); err != nil {
+		t.Fatalf("failed to create istio telemetry resource: %v", err)
+	}
+}
+func createTestNamespace(ctx context.Context, c client.Client, istioInjection bool, t *testing.T) string {
+	t.Helper()
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-egress-",
+			Labels: func() map[string]string {
+				if istioInjection {
+					return map[string]string{"istio-injection": "enabled"}
+				}
+				return nil
+			}(),
+		},
+	}
+	t.Cleanup(func() {
+		_ = c.Delete(ctx, &ns)
+	})
+	if err := c.Create(ctx, &ns); err != nil {
+		t.Errorf("failed to create namespace: %v", err)
+	}
+	return ns.Name
+}
+func runCurlInPod(ctx context.Context, cfg *rest.Config, namespace string, command []string) ([]byte, error) {
+	c, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	run := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "curl-",
+			Namespace:    namespace,
+			Labels:       map[string]string{"test-workload": "true"},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "curl",
+					Image:   "curlimages/curl",
+					Command: command,
+				},
+			},
+		},
+	}
+	run, err = c.CoreV1().Pods(namespace).Create(ctx, run, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var exitCode int32
+	err = wait.ExponentialBackoffWithContext(ctx, defaultWaitBackoff, func(ctx context.Context) (bool, error) {
+		p, err := c.CoreV1().Pods(namespace).Get(ctx, run.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(p.Status.ContainerStatuses) == 0 {
+			return false, nil
+		}
+		for _, s := range p.Status.ContainerStatuses {
+			if s.Name == "curl" && s.State.Terminated != nil {
+				exitCode = s.State.Terminated.ExitCode
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	out, err := c.CoreV1().Pods(namespace).GetLogs(run.Name, &corev1.PodLogOptions{Container: "curl"}).DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if exitCode != 0 {
+		return out, fmt.Errorf("non-zero exit code: %v", exitCode)
+	}
+
+	return out, nil
+}
+func applyNetworPolicy(ctx context.Context, c client.Client, t *testing.T, namespace string) {
+	t.Helper()
+	np := networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-network-policy-",
+			Namespace:    namespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-system",
+							}},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: ptr.To(corev1.ProtocolUDP),
+							Port:     ptr.To(intstr.FromInt32(53)),
+						},
+					},
+				},
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "istio-system",
+							}},
+						},
+					},
+				},
+			}},
+	}
+	if err := c.Create(ctx, &np); err != nil {
+		t.Errorf("failed to create NetworkPolicy: %v", err)
+	}
+}
+func applyEgressConfig(ctx context.Context, c client.Client, namespace string) error {
+	// TODO (@Ressetkk): set up fixture to define different types of configuration (HTTP, TLS, TLS Origination)
+	sEntry := &istionetworkingv1.ServiceEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-service-entry-",
+			Namespace:    namespace,
+		},
+		Spec: v1alpha3.ServiceEntry{
+			Hosts: []string{"httpbin.org"},
+			Ports: []*v1alpha3.ServicePort{
+				{
+					Name:     "tls",
+					Number:   443,
+					Protocol: "TLS",
+				},
+			},
+			Resolution: v1alpha3.ServiceEntry_DNS,
+		},
+	}
+	if err := c.Create(ctx, sEntry); err != nil {
+		return err
+	}
+	gateway := &istionetworkingv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "egress-gateway-",
+			Namespace:    namespace,
+		},
+		Spec: v1alpha3.Gateway{
+			Selector: map[string]string{"istio": "egressgateway"},
+			Servers: []*v1alpha3.Server{
+				{
+					Port: &v1alpha3.Port{
+						Number:   443,
+						Protocol: "TLS",
+						Name:     "tls",
+					},
+					Hosts: []string{"httpbin.org"},
+					Tls:   &v1alpha3.ServerTLSSettings{Mode: v1alpha3.ServerTLSSettings_PASSTHROUGH},
+				},
+			},
+		},
+	}
+	if err := c.Create(ctx, gateway); err != nil {
+		return err
+	}
+	dr := &istionetworkingv1.DestinationRule{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "egress-dr-",
+			Namespace:    namespace,
+		},
+		Spec: v1alpha3.DestinationRule{
+			Host: "istio-egressgateway.istio-system.svc.cluster.local",
+			Subsets: []*v1alpha3.Subset{
+				{
+					Name: "kyma-project",
+				},
+			},
+		},
+	}
+	if err := c.Create(ctx, dr); err != nil {
+		return err
+	}
+	vs := &istionetworkingv1.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "egress-vs-",
+			Namespace:    namespace,
+		},
+		Spec: v1alpha3.VirtualService{
+			Hosts:    []string{"httpbin.org"},
+			Gateways: []string{gateway.Name, "mesh"},
+			Tls: []*v1alpha3.TLSRoute{
+				{
+					Match: []*v1alpha3.TLSMatchAttributes{
+						{
+							Gateways: []string{"mesh"},
+							Port:     443,
+							SniHosts: []string{"httpbin.org"},
+						},
+					},
+					Route: []*v1alpha3.RouteDestination{
+						{
+							Destination: &v1alpha3.Destination{
+								Host:   "istio-egressgateway.istio-system.svc.cluster.local",
+								Subset: "kyma-project",
+								Port:   &v1alpha3.PortSelector{Number: 443},
+							},
+						},
+					},
+				},
+				{
+					Match: []*v1alpha3.TLSMatchAttributes{
+						{
+							Gateways: []string{gateway.Name},
+							Port:     443,
+							SniHosts: []string{"httpbin.org"},
+						},
+					},
+					Route: []*v1alpha3.RouteDestination{
+						{
+							Destination: &v1alpha3.Destination{
+								Host: "httpbin.org",
+								Port: &v1alpha3.PortSelector{Number: 443},
+							},
+							Weight: 100,
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := c.Create(ctx, vs); err != nil {
+		return err
+	}
+	return nil
+}
+func initK8sClient(config *rest.Config) (client.Client, error) {
+	// (@Ressetkk): it would be better to remove usage of controller-runtime client.Client
+	// 	and generate ClientSet for our API using client-gen, as we need to sometimes use non-CRUD operations, which
+	//	 controller-runtime does not implement.
+	c, err := client.New(config, client.Options{})
+	if err != nil {
+		return nil, err
+	}
+
+	_ = operatorv1alpha2.AddToScheme(c.Scheme())
+	_ = istionetworkingv1.AddToScheme(c.Scheme())
+	_ = istiotelemetryv1.AddToScheme(c.Scheme())
+
+	return c, nil
+}

--- a/tests/integration/steps/deployment.go
+++ b/tests/integration/steps/deployment.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+
 	"github.com/kyma-project/istio/operator/tests/testcontext"
 
 	"github.com/avast/retry-go"
@@ -341,7 +342,7 @@ func getPodList(ctx context.Context, k8sClient client.Client, podList *corev1.Po
 func getVersionFromImageName(image string) (string, error) {
 	noVersion := ""
 	matches := reference.ReferenceRegexp.FindStringSubmatch(image)
-	if matches == nil || len(matches) < 3 {
+	if len(matches) < 3 {
 		return noVersion, fmt.Errorf("unable to parse container image reference: %s", image)
 	}
 	version, err := semver.NewVersion(matches[2])


### PR DESCRIPTION
* Add simple e2e test for egress TLS gateway
* Add small documentation on writing E2E tests from scratch
* Add new Makefile target to run E2E tests. It uses gotestsum to generate nice summary of the tests without additional effort from the developer.
* Add `test-e2e` to Matrixes of gardener tests on post and release workflows.

This tests implements the official Istio egress tutorial with TLS passthrough.

Note that this test will work only on a cluster that supports NetworkPolicy.

**K3s/K3d uses flannel as CNI. Flannel does not support NetworkPolicies very well!**

For local cluster only kind supports NetworkPolicies. If we don't want to spend a lot of money on gardener clusters, we should invest in using kind locally and in CI one day.

#1201 