### PR TITLE
bug: add OpenStack proxy protocol annotation

### DIFF
--- a/internal/istiooperator/istio-operator-light.yaml
+++ b/internal/istiooperator/istio-operator-light.yaml
@@ -242,6 +242,7 @@ spec:
         serviceAnnotations:
           service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
           service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
+          loadbalancer.openstack.org/proxy-protocol: "v1"
           istios.operator.kyma-project.io/managed-by-disclaimer: |
             DO NOT EDIT - This resource is managed by Kyma.
             Any modifications are discarded and the resource is reverted to the original state.

--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -295,6 +295,7 @@ spec:
         serviceAnnotations:
           service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
           service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
+          loadbalancer.openstack.org/proxy-protocol: "v1"
           istios.operator.kyma-project.io/managed-by-disclaimer: |
             DO NOT EDIT - This resource is managed by Kyma.
             Any modifications are discarded and the resource is reverted to the original state.


### PR DESCRIPTION
Add openstack proxy-protocol annotation in istio-ingressgateway service configuration

This enables proxy-protocol in version 1 on a service in OpenStack. Proxy-protocol is not supported by EnvoyFilter and needs to be handled separately.

It enables the proxy-protocol the same way it's enabled on AWS LB.

#1261 