### PR TITLE
bug: increase backoff on e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ $(ENVTEST): $(LOCALBIN)
 
 .PHONY: test-e2e
 test-e2e: gotestsum
-	$(LOCALBIN)/gotestsum --format "testname" -- -run '^TestE2E.*' ./tests/e2e/...
+	$(LOCALBIN)/gotestsum --rerun-fails --packages="./tests/e2e/..." --format "testname" -- -run '^TestE2E.*' ./tests/e2e/...
 ##@ Module
 
 .PHONY: module-image

--- a/tests/e2e/egress/egress_test.go
+++ b/tests/e2e/egress/egress_test.go
@@ -26,9 +26,9 @@ import (
 
 var (
 	defaultWaitBackoff = wait.Backoff{
-		Cap:      3 * time.Minute,
+		Cap:      10 * time.Minute,
 		Duration: time.Second,
-		Steps:    10,
+		Steps:    30,
 		Factor:   1.5,
 	}
 )


### PR DESCRIPTION
Gardener is flaky. Increase timeout to 10 min for all retryable logic.

Add `--rerun-fails` to rerun failed tests in case of flakiness, and to give infra time to potentially settle.

#1201 