### PR TITLE
bug: remove test-e2e from GCP integration tests

### DIFF
--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-e2e", "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
+        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Remove e2e-test execution for gardener GCP until issue with Gardener GCP networkPolicy is resolved.