### PR TITLE
bug: remove test-e2e from GCP integration tests 2

### DIFF
--- a/.github/workflows/post-main-workflow.yaml
+++ b/.github/workflows/post-main-workflow.yaml
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-e2e", "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
+        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test" ]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Remove e2e-test execution for gardener GCP until issue with Gardener GCP networkPolicy is resolved.
