### PR TITLE
Run schedule main job one hour before to not clash with Api Gateway

### DIFF
--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -4,7 +4,7 @@ name: Schedule Daily
 
 on:
   schedule:
-    - cron: '0 5 * * *' # Run every day at 6:00 CET (5:00 UTC)
+    - cron: '0 4 * * *' # Run every day at 5:00 CET (4:00 UTC)
 
 jobs:
   get-sha:


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change cron expression in schedule main job to run one hour earlier than in the API Gateway repository to not utilize too much resources at the same time

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
