### PR TITLE
feat: Enable Istio access logs via OTLP to Telemetry Log Gateway

### DIFF
--- a/internal/istiooperator/istio-operator-light.yaml
+++ b/internal/istiooperator/istio-operator-light.yaml
@@ -193,12 +193,14 @@ spec:
       opentelemetry:
           service: "telemetry-otlp-traces.kyma-system.svc.cluster.local"
           port: 4317
-    - envoyFileAccessLog:
+    - name: envoy
+      envoyFileAccessLog:
+        path: /dev/stdout
         logFormat:
           labels: {}
+    - name: stdout-json
+      envoyFileAccessLog:
         path: /dev/stdout
-      name: envoy
-    - envoyFileAccessLog:
         logFormat:
           labels:
             start_time: "%START_TIME%"
@@ -227,8 +229,40 @@ spec:
             route_name: "%ROUTE_NAME%"
             traceparent: "%REQ(TRACEPARENT)%"
             tracestate: "%REQ(TRACESTATE)%"
-        path: /dev/stdout
-      name: stdout-json
+    - name: kyma-logs
+      envoyOtelAls:
+        service: telemetry-otlp-logs.kyma-system.svc.cluster.local
+        port: 4317
+        logName: kyma-logs
+        logFormat:
+          text: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% - - [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %BYTES_SENT%'
+          labels:
+            http.request.size: '%CEL(request.total_size)%'
+            http.request.body.size: '%CEL(request.size)%'
+            http.request.method: '%CEL(request.method)%'
+            http.request.duration: '%CEL(request.duration.getMilliseconds())%'
+            http.response.size: '%CEL(response.total_size)%'
+            http.response.body.size: '%CEL(response.size)%'
+            http.response.status_code: '%CEL(response.code)%'
+            http.request.header.x-forwarded-for: '%CEL(request.headers[X-FORWARDED-FOR])%'
+            http.request.header.x-request-id: '%CEL(request.id)%'
+            http.request.header.referer: '%CEL(request.referer)%'
+            url.scheme: '%CEL(request.scheme)%'
+            url.path: '%CEL(request.url_path)%'
+            url.query: '%CEL(request.query)%'
+            user_agent.original: '%CEL(request.useragent)%'
+            server.address: '%CEL(request.host)%'  # will contain the port occasionally as well. Latest envoy release will support regex grouping to extract protocol
+            server.port: '%CEL(xds.listener_direction==1?destination.port:upstream.port)%'
+            client.address: '%CEL(xds.listener_direction==1?source.address:upstream.local_address)%'
+            client.port: '%CEL(xds.listener_direction==1?source.port:"")%'
+            network.peer.address: '%CEL(xds.listener_direction==1?source.address:upstream.address)%'
+            network.peer.port: '%CEL(xds.listener_direction==1?source.port:upstream.port)%'
+            network.local.address: '%CEL(xds.listener_direction==1?destination.address:upstream.local_address)%'
+            network.local.port: '%CEL(xds.listener_direction==1?destination.port:"")%'
+            network.protocol.name: '%CEL(request.protocol)%' # will contain the version as well. Latest envoy release will support regex grouping to extract protocol
+            tls.protocol.name: '%CEL(xds.listener_direction==1?connection.tls_version:upstream.tls_version)%' # will contain the version as well. Latest envoy release will support regex grouping to extract protocol
+            http.direction: '%CEL(xds.listener_direction==1?"inbound":(xds.listener_direction==2?"outbound":""))%' # not aligned with conventions
+            kyma.component: istio
     trustDomain: cluster.local
   profile: default
   values:

--- a/internal/istiooperator/istio-operator-light.yaml
+++ b/internal/istiooperator/istio-operator-light.yaml
@@ -238,11 +238,9 @@ spec:
           text: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% - - [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %BYTES_SENT%'
           labels:
             http.request.size: '%CEL(request.total_size)%'
-            http.request.body.size: '%CEL(request.size)%'
             http.request.method: '%CEL(request.method)%'
             http.request.duration: '%CEL(request.duration.getMilliseconds())%'
             http.response.size: '%CEL(response.total_size)%'
-            http.response.body.size: '%CEL(response.size)%'
             http.response.status_code: '%CEL(response.code)%'
             http.request.header.x-forwarded-for: '%CEL(request.headers[X-FORWARDED-FOR])%'
             http.request.header.x-request-id: '%CEL(request.id)%'
@@ -251,18 +249,12 @@ spec:
             url.path: '%CEL(request.url_path)%'
             url.query: '%CEL(request.query)%'
             user_agent.original: '%CEL(request.useragent)%'
-            server.address: '%CEL(request.host)%'  # will contain the port occasionally as well. Latest envoy release will support regex grouping to extract protocol
+            server.address: '%CEL(request.host)%'
             server.port: '%CEL(xds.listener_direction==1?destination.port:upstream.port)%'
             client.address: '%CEL(xds.listener_direction==1?source.address:upstream.local_address)%'
-            client.port: '%CEL(xds.listener_direction==1?source.port:"")%'
-            network.peer.address: '%CEL(xds.listener_direction==1?source.address:upstream.address)%'
-            network.peer.port: '%CEL(xds.listener_direction==1?source.port:upstream.port)%'
-            network.local.address: '%CEL(xds.listener_direction==1?destination.address:upstream.local_address)%'
-            network.local.port: '%CEL(xds.listener_direction==1?destination.port:"")%'
-            network.protocol.name: '%CEL(request.protocol)%' # will contain the version as well. Latest envoy release will support regex grouping to extract protocol
-            tls.protocol.name: '%CEL(xds.listener_direction==1?connection.tls_version:upstream.tls_version)%' # will contain the version as well. Latest envoy release will support regex grouping to extract protocol
-            http.direction: '%CEL(xds.listener_direction==1?"inbound":(xds.listener_direction==2?"outbound":""))%' # not aligned with conventions
-            kyma.component: istio
+            client.port: '%CEL(xds.listener_direction==1?source.port:nil)%'
+            http.direction: '%CEL(xds.listener_direction==1?"inbound":(xds.listener_direction==2?"outbound":nil))%'
+            kyma.module: istio
     trustDomain: cluster.local
   profile: default
   values:

--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -291,11 +291,9 @@ spec:
           text: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% - - [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %BYTES_SENT%'
           labels:
             http.request.size: '%CEL(request.total_size)%'
-            http.request.body.size: '%CEL(request.size)%'
             http.request.method: '%CEL(request.method)%'
             http.request.duration: '%CEL(request.duration.getMilliseconds())%'
             http.response.size: '%CEL(response.total_size)%'
-            http.response.body.size: '%CEL(response.size)%'
             http.response.status_code: '%CEL(response.code)%'
             http.request.header.x-forwarded-for: '%CEL(request.headers[X-FORWARDED-FOR])%'
             http.request.header.x-request-id: '%CEL(request.id)%'
@@ -304,18 +302,12 @@ spec:
             url.path: '%CEL(request.url_path)%'
             url.query: '%CEL(request.query)%'
             user_agent.original: '%CEL(request.useragent)%'
-            server.address: '%CEL(request.host)%'  # will contain the port occasionally as well. Latest envoy release will support regex grouping to extract protocol
+            server.address: '%CEL(request.host)%'
             server.port: '%CEL(xds.listener_direction==1?destination.port:upstream.port)%'
             client.address: '%CEL(xds.listener_direction==1?source.address:upstream.local_address)%'
-            client.port: '%CEL(xds.listener_direction==1?source.port:"")%'
-            network.peer.address: '%CEL(xds.listener_direction==1?source.address:upstream.address)%'
-            network.peer.port: '%CEL(xds.listener_direction==1?source.port:upstream.port)%'
-            network.local.address: '%CEL(xds.listener_direction==1?destination.address:upstream.local_address)%'
-            network.local.port: '%CEL(xds.listener_direction==1?destination.port:"")%'
-            network.protocol.name: '%CEL(request.protocol)%' # will contain the version as well. Latest envoy release will support regex grouping to extract protocol
-            tls.protocol.name: '%CEL(xds.listener_direction==1?connection.tls_version:upstream.tls_version)%' # will contain the version as well. Latest envoy release will support regex grouping to extract protocol
-            http.direction: '%CEL(xds.listener_direction==1?"inbound":(xds.listener_direction==2?"outbound":""))%' # not aligned with conventions
-            kyma.component: istio
+            client.port: '%CEL(xds.listener_direction==1?source.port:nil)%'
+            http.direction: '%CEL(xds.listener_direction==1?"inbound":(xds.listener_direction==2?"outbound":nil))%'
+            kyma.module: istio
     trustDomain: cluster.local
   profile: default
   values:

--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -246,12 +246,14 @@ spec:
       opentelemetry:
           service: "telemetry-otlp-traces.kyma-system.svc.cluster.local"
           port: 4317
-    - envoyFileAccessLog:
+    - name: envoy
+      envoyFileAccessLog:
+        path: /dev/stdout
         logFormat:
           labels: {}
+    - name: stdout-json
+      envoyFileAccessLog:
         path: /dev/stdout
-      name: envoy
-    - envoyFileAccessLog:
         logFormat:
           labels:
             start_time: "%START_TIME%"
@@ -280,8 +282,40 @@ spec:
             route_name: "%ROUTE_NAME%"
             traceparent: "%REQ(TRACEPARENT)%"
             tracestate: "%REQ(TRACESTATE)%"
-        path: /dev/stdout
-      name: stdout-json
+    - name: kyma-logs
+      envoyOtelAls:
+        service: telemetry-otlp-logs.kyma-system.svc.cluster.local
+        port: 4317
+        logName: kyma-logs
+        logFormat:
+          text: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% - - [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %BYTES_SENT%'
+          labels:
+            http.request.size: '%CEL(request.total_size)%'
+            http.request.body.size: '%CEL(request.size)%'
+            http.request.method: '%CEL(request.method)%'
+            http.request.duration: '%CEL(request.duration.getMilliseconds())%'
+            http.response.size: '%CEL(response.total_size)%'
+            http.response.body.size: '%CEL(response.size)%'
+            http.response.status_code: '%CEL(response.code)%'
+            http.request.header.x-forwarded-for: '%CEL(request.headers[X-FORWARDED-FOR])%'
+            http.request.header.x-request-id: '%CEL(request.id)%'
+            http.request.header.referer: '%CEL(request.referer)%'
+            url.scheme: '%CEL(request.scheme)%'
+            url.path: '%CEL(request.url_path)%'
+            url.query: '%CEL(request.query)%'
+            user_agent.original: '%CEL(request.useragent)%'
+            server.address: '%CEL(request.host)%'  # will contain the port occasionally as well. Latest envoy release will support regex grouping to extract protocol
+            server.port: '%CEL(xds.listener_direction==1?destination.port:upstream.port)%'
+            client.address: '%CEL(xds.listener_direction==1?source.address:upstream.local_address)%'
+            client.port: '%CEL(xds.listener_direction==1?source.port:"")%'
+            network.peer.address: '%CEL(xds.listener_direction==1?source.address:upstream.address)%'
+            network.peer.port: '%CEL(xds.listener_direction==1?source.port:upstream.port)%'
+            network.local.address: '%CEL(xds.listener_direction==1?destination.address:upstream.local_address)%'
+            network.local.port: '%CEL(xds.listener_direction==1?destination.port:"")%'
+            network.protocol.name: '%CEL(request.protocol)%' # will contain the version as well. Latest envoy release will support regex grouping to extract protocol
+            tls.protocol.name: '%CEL(xds.listener_direction==1?connection.tls_version:upstream.tls_version)%' # will contain the version as well. Latest envoy release will support regex grouping to extract protocol
+            http.direction: '%CEL(xds.listener_direction==1?"inbound":(xds.listener_direction==2?"outbound":""))%' # not aligned with conventions
+            kyma.component: istio
     trustDomain: cluster.local
   profile: default
   values:


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The telemetry module is introducing support for OTLP based ingestion and export of logs, see https://github.com/kyma-project/telemetry-manager/issues/556. Hereby, logs collected via stdout will be shipped differently then before (protocol, attribute naming, anything) and users need to adopt.

Currently, Istio access logs are supported via printing JSON to stdout, using the "stdout-json" Istio extension provider. As users need to adopt when switching to OTLP, we directly like to add Istio access logs support via OTLP as well, so that users need to adopt once only.

This PR introduces a new Istio "envoyOtelAls" extension provider "kyma-logs" (analogue to "kyma-traces") which will push access logs to the upcoming telemetry log gateway.

There is no default format for defining the log body and the attributes, that's why in https://github.com/kyma-project/telemetry-manager/issues/1899 a detailed analysis was done to see how to map existing attributes to the OTEL semantic conventions. The proposal was crosschecked by the SAP Cloud Logging team. As a result, this PR configures a log body using the most simple default apache access log format and defines attributes which are mainly derived from the pattern before but using otel conventions.

Additionally, one log attribute gets added to indicate for the telemetry log gateway that this log data is emmitted by Istio. Unfortunately, no better way was found as typical patterns like setting an instrumentation scope on the OTEL data is not supported by Istio yet.

Changes proposed in this pull request:

- Adds a new extension provider for access logs via OTLP

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
