### PR TITLE
Wait for the ingress in the performance test, added sleep commands to ensure that workloads are ready

### DIFF
--- a/tests/performance/Makefile
+++ b/tests/performance/Makefile
@@ -1,5 +1,5 @@
 OS_ARCH ?= $(shell uname | awk '{print tolower($0)}')
-KYMA_DOMAIN ?= $(shell kubectl config view -o json | jq '.clusters[0].cluster.server' | sed -e "s/https:\/\/api.//" -e 's/"//g')
+KYMA_DOMAIN ?= $(shell kubectl get configmap -n kube-system shoot-info -o jsonpath="{.data.domain}")
 
 load-testing/charts/plutono:
 	mkdir load-testing/charts
@@ -10,6 +10,7 @@ deploy-helm:
 	helm dependency update load-testing
 
 	helm upgrade --install load-testing load-testing --set IngressGatewayIP=$(shell ip=$$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'); hostname=$$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'); if [ -n "$$ip" ]; then echo "$$ip"; else echo "$$hostname"; fi) --set Domain=${KYMA_DOMAIN} --create-namespace --wait
+	until curl --silent --output /dev/null "https://any-host.${KYMA_DOMAIN}/"; echo "Waiting for the load balancer to respond on https://any-host.${KYMA_DOMAIN}"; do sleep 10; done
 
 test-deploy:
 	kubectl rollout status deployment/load-testing
@@ -18,6 +19,7 @@ test-deploy:
 test-performance: deploy-max-replicas-istio deploy-helm test-deploy
 	kubectl patch deployment/load-testing --type merge --patch-file istio-disabled.yaml
 	kubectl rollout status deployment/load-testing
+	sleep 60
 	kubectl exec -q $(shell kubectl get pods --selector=app=k6 -o jsonpath='{.items[0].metadata.name}') -- k6 run run.js -d 1m --vus 500 --out influxdb=http://load-testing-influxdb:8086/k6 --log-output none --system-tags=method,name,status,tag -e DOMAIN=${KYMA_DOMAIN};\
 	EXIT_CODE=$$?;\
 	echo "Performance test without sidecar test completed with exit code $$EXIT_CODE"
@@ -26,6 +28,7 @@ test-performance: deploy-max-replicas-istio deploy-helm test-deploy
 
 	kubectl patch deployment/load-testing --type merge --patch-file istio-enabled.yaml
 	kubectl rollout status deployment/load-testing
+	sleep 60
 	kubectl exec -q $(shell kubectl get pods --selector=app=k6 -o jsonpath='{.items[0].metadata.name}') -- k6 run run.js -d 1m --vus 500 --out influxdb=http://load-testing-influxdb:8086/k6 --log-output none --system-tags=method,name,status,tag -e DOMAIN=${KYMA_DOMAIN};\
 	EXIT_CODE=$$?;\
 	echo "Performance test with sidecar test completed with exit code $$EXIT_CODE"
@@ -37,6 +40,7 @@ test-performance: deploy-max-replicas-istio deploy-helm test-deploy
 test-performance-web: deploy-max-replicas-istio deploy-helm test-deploy
 	kubectl patch deployment/load-testing --type merge --patch-file istio-disabled.yaml
 	kubectl rollout status deployment/load-testing
+	sleep 60
 	kubectl exec -q $(shell kubectl get pods --selector=app=k6 -o jsonpath='{.items[0].metadata.name}') -- k6 run run.js -d 1m --vus 500 --log-output none --system-tags=method,name,status,tag -e DOMAIN=${KYMA_DOMAIN} -e K6_WEB_DASHBOARD=true -e K6_WEB_DASHBOARD_EXPORT=summary.html;\
 	EXIT_CODE=$$?;\
 	echo "Performance test without sidecar test completed with exit code $$EXIT_CODE"
@@ -45,6 +49,7 @@ test-performance-web: deploy-max-replicas-istio deploy-helm test-deploy
 
 	kubectl patch deployment/load-testing --type merge --patch-file istio-enabled.yaml
 	kubectl rollout status deployment/load-testing
+	sleep 60
 	kubectl exec -q $(shell kubectl get pods --selector=app=k6 -o jsonpath='{.items[0].metadata.name}') -- k6 run run.js -d 1m --vus 500 --log-output none --system-tags=method,name,status,tag -e DOMAIN=${KYMA_DOMAIN} -e K6_WEB_DASHBOARD=true -e K6_WEB_DASHBOARD_EXPORT=summary.html;\
 	EXIT_CODE=$$?;\
 	echo "Performance test with sidecar test completed with exit code $$EXIT_CODE"
@@ -55,8 +60,5 @@ deploy-max-replicas-istio:
 	kubectl apply -f istio-max-replicas.yaml
 	kubectl wait --for='jsonpath={.status.state}=Ready' --timeout=5m -n kyma-system istio default
 	kubectl wait -n istio-system --for=jsonpath='{.status.loadBalancer.ingress}' --timeout=5m service/istio-ingressgateway
-
-	domain=$(shell kubectl config view -o json | jq '.clusters[0].cluster.server' | sed -e "s/https:\/\/api.//" -e 's/"//g');\
-	kubectl annotate service -n istio-system istio-ingressgateway "dns.gardener.cloud/dnsnames=*.${domain}" --overwrite
 
 .PHONY: test-performance deploy-max-replicas-istio deploy-helm test-deploy


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Wait for Ingress to respond after helm is chart is installed in the performance tests
- Added sleep command after workload deployment to postpone performance test execution (to ensure that workloads are 'ready', not only started)
- More reliable and simpler way of getting domain name

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
