### PR TITLE
Revert "Update k3s version to 1.31.7"

### DIFF
--- a/.github/actions/e2e-test-k3d/action.yaml
+++ b/.github/actions/e2e-test-k3d/action.yaml
@@ -22,7 +22,7 @@ runs:
     - name: Create Cluster
       uses: ./.github/actions/provision-k3d-cluster
       with:
-        k3s-version: "1.31.7"
+        k3s-version: "1.31.6"
         agents: ${{ inputs.agents }}
         servers-memory: ${{ inputs.servers-memory }}
     - name: Run integration tests


### PR DESCRIPTION
Reverts kyma-project/istio#1403

There is an incompatibility between the newest k3s and the Istio CNI