### PR TITLE
bug: add missing gardener IP ranges for services

### DIFF
--- a/tests/e2e/egress/egress_test.go
+++ b/tests/e2e/egress/egress_test.go
@@ -280,6 +280,23 @@ func applyNetworPolicy(ctx context.Context, c client.Client, t *testing.T, names
 				{
 					To: []networkingv1.NetworkPolicyPeer{
 						{
+							IPBlock: &networkingv1.IPBlock{
+								CIDR: "169.254.20.10/32",
+							},
+						},
+						{
+							IPBlock: &networkingv1.IPBlock{
+								// this can cause the test to fail if the Service IP range changes in different clusters.
+								// Proceed with caution.
+								CIDR: "100.104.0.0/13",
+							},
+						},
+						{
+							IPBlock: &networkingv1.IPBlock{
+								CIDR: "fd30:1319:f1e:230b::1/128",
+							},
+						},
+						{
 							NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 								"kubernetes.io/metadata.name": "kube-system",
 							}},


### PR DESCRIPTION
Gardener topology is a little bit different than standard Kubernetes one. DNS Service is working in host network mode. This disrupts the behaviour of NetworkPolicy.

This change requires the NetworkPolicy to contain the IP CIDR of services used for connectivity.

`100.104.0.0/13` is a default Service IP range when gardener cluster is created.

Tested against Gardeners on different providers, and locally in kind.