### PR TITLE
fix: Warning should not happen when ReplicaSet is not ready

### DIFF
--- a/pkg/lib/sidecars/restart/log_action.go
+++ b/pkg/lib/sidecars/restart/log_action.go
@@ -1,0 +1,18 @@
+package restart
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type logAction struct {
+	message string
+}
+
+func (r logAction) run(_ context.Context, _ client.Client, object actionObject, l *logr.Logger) ([]RestartWarning, error) {
+	l.Info(r.message, "kind", object.Kind, "name", object.Name, "namespace", object.Namespace)
+	return []RestartWarning{}, nil
+}

--- a/pkg/lib/sidecars/restart/replica_set_action.go
+++ b/pkg/lib/sidecars/restart/replica_set_action.go
@@ -65,7 +65,7 @@ func getReplicaSetAction(ctx context.Context, c client.Client, pod v1.Pod, repli
 						Namespace: replicaSet.Namespace,
 						Kind:      rsOwnedBy.Kind,
 					},
-					run: warningAction{message: notReadyReplicaSetExistsMessage}.run,
+					run: logAction{message: notReadyReplicaSetExistsMessage}.run,
 				}, nil
 			}
 		}

--- a/pkg/lib/sidecars/restart/restart_test.go
+++ b/pkg/lib/sidecars/restart/restart_test.go
@@ -3,6 +3,7 @@ package restart_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -32,6 +33,31 @@ func TestRestartPods(t *testing.T) {
 var _ = ReportAfterSuite("custom reporter", func(report ginkgotypes.Report) {
 	tests.GenerateGinkgoJunitReport("pods-restart-suite", report)
 })
+
+type mockLogSink struct {
+	infos chan string
+	errs  chan error
+}
+
+func (m mockLogSink) Init(_ logr.RuntimeInfo) {}
+
+func (m mockLogSink) Enabled(_ int) bool {
+	return true
+}
+
+func (m mockLogSink) Info(_ int, msg string, keysAndValues ...any) {
+	m.infos <- fmt.Sprintf("%s %v", msg, keysAndValues)
+}
+
+func (m mockLogSink) Error(_ error, _ string, _ ...any) {}
+
+func (m mockLogSink) WithValues(_ ...any) logr.LogSink {
+	return m
+}
+
+func (m mockLogSink) WithName(_ string) logr.LogSink {
+	return m
+}
 
 var _ = Describe("Restart Pods", func() {
 	ctx := context.Background()
@@ -366,20 +392,24 @@ var _ = Describe("Restart Pods", func() {
 				UID:       "1234",
 			}})
 
+		sink := mockLogSink{
+			infos: make(chan string, 1),
+			errs:  make(chan error, 1),
+		}
+
+		l := logr.New(sink)
+
 		// when
-		actionRestarter := restart.NewActionRestarter(c, &logger)
+		actionRestarter := restart.NewActionRestarter(c, &l)
 		warnings, err := actionRestarter.Restart(ctx, &podList, false)
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
-		Expect(warnings).To(ContainElement(
-			restart.RestartWarning{
-				Name:      "rsOwner",
-				Namespace: "test-ns",
-				Kind:      "Deployment",
-				Message:   "was not restarted because there exists another not ready ReplicaSet for the same object",
-			}),
-		)
+		Expect(warnings).To(BeEmpty())
+
+		Expect(sink.infos).To(Not(BeEmpty()))
+		Eventually(sink.infos).Should(Receive(Equal("was not restarted because there exists another not ready " +
+			"ReplicaSet for the same object [kind Deployment name rsOwner namespace test-ns]")))
 
 		deployment := appsv1.Deployment{}
 		err = c.Get(context.Background(), types.NamespacedName{Name: "rsOwner", Namespace: "test-ns"}, &deployment)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Warning should not happen when ReplicaSet is not ready

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
