### PR TITLE
[release 1.17] fix: Warning should not happen when ReplicaSet is not ready

### DIFF
--- a/pkg/lib/sidecars/restart/log_action.go
+++ b/pkg/lib/sidecars/restart/log_action.go
@@ -1,0 +1,18 @@
+package restart
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type logAction struct {
+	message string
+}
+
+func (r logAction) run(_ context.Context, _ client.Client, object actionObject, l *logr.Logger) ([]RestartWarning, error) {
+	l.Info(r.message, "kind", object.Kind, "name", object.Name, "namespace", object.Namespace)
+	return []RestartWarning{}, nil
+}

--- a/pkg/lib/sidecars/restart/replica_set_action.go
+++ b/pkg/lib/sidecars/restart/replica_set_action.go
@@ -65,7 +65,7 @@ func getReplicaSetAction(ctx context.Context, c client.Client, pod v1.Pod, repli
 						Namespace: replicaSet.Namespace,
 						Kind:      rsOwnedBy.Kind,
 					},
-					run: warningAction{message: notReadyReplicaSetExistsMessage}.run,
+					run: logAction{message: notReadyReplicaSetExistsMessage}.run,
 				}, nil
 			}
 		}


### PR DESCRIPTION
* fix: Warning should not happen when ReplicaSet is not ready

* Make channel unbuffered

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Cherrypick #1447

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
