### PR TITLE
Fix docs: state of IstioCR for user resource detection

### DIFF
--- a/docs/user/04-00-istio-custom-resource.md
+++ b/docs/user/04-00-istio-custom-resource.md
@@ -128,6 +128,6 @@ See the possible values of the **status.conditions** fields:
 | `Error`          | `Ready`                             | `False`   | `EgressGatewayReconcileFailed`                | Istio Egress Gateway reconciliation failed.                                               |
 | `Warning`        | `Ready`                             | `False`   | `IstioVersionUpdateNotAllowed`                | Update to the new Istio version is not allowed.                                           |
 | `Warning`        | `IngressTargetingUserResourceFound` | `True`    | `IngressTargetingUserResourceFound`           | Resource targeting Istio Ingress Gateway found.                                           |
-| `Warning`        | `IngressTargetingUserResourceFound` | `False`   | `IngressTargetingUserResourceFound`           | Resources targeting Istio Ingress Gateway not found. (default state)                      |
+| `Ready`          | `IngressTargetingUserResourceFound` | `False`   | `IngressTargetingUserResourceFound`           | Resources targeting Istio Ingress Gateway not found. (default state)                      |
 | `Warning`        | `IngressTargetingUserResourceFound` | `Unknown` | `IngressTargetingUserResourceDetectionFailed` | Resource targeting Istio Ingress Gateway detection failed.                                |
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix for the docs, there is a Ready state on IstioCR if there is no user created EF in the cluster

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
