### PR TITLE
bug: Fix labels reconciliation in resource manager

### DIFF
--- a/.github/actions/build-manager-image/action.yaml
+++ b/.github/actions/build-manager-image/action.yaml
@@ -48,6 +48,8 @@ runs:
         push: false
         load: true
         tags: ${{ inputs.operator-image-name }}
+        build-args: |
+          VERSION=${{ inputs.operator-version }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         outputs: type=docker,dest=/tmp/manager-image.tar

--- a/.github/actions/build-manager-image/action.yaml
+++ b/.github/actions/build-manager-image/action.yaml
@@ -4,6 +4,9 @@ inputs:
   operator-image-name:
     description: 'Operator image name used for creation of Istio manager image'
     required: true
+  operator-version:
+    description: 'Version of the operator'
+    required: true
   push-image:
     description: 'Push the image to GCP'
     required: false
@@ -32,6 +35,8 @@ runs:
         platforms: 'linux/amd64'
         push: true
         tags: ${{ inputs.operator-image-name }}
+        build-args: |
+          VERSION=${{ inputs.operator-version }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
     - name: Build and Load

--- a/.github/actions/e2e-test-gardener/action.yaml
+++ b/.github/actions/e2e-test-gardener/action.yaml
@@ -16,6 +16,9 @@ inputs:
   test_make_target:
     description: 'Make target for integration tests to run'
     required: true
+  operator_version:
+    description: 'Version of the operator image'
+    required: true
 
 runs:
   using: "composite"
@@ -51,6 +54,7 @@ runs:
       env:
         IMG: ${{ inputs.manager_image }}
         CLUSTER_KUBECONFIG: "${{ github.workspace }}/${{ env.CLUSTER_NAME }}_kubeconfig.yaml"
+        OPERATOR_VERSION: ${{ inputs.operator_version }}
       run: EXPORT_RESULT=true "${{ github.workspace }}/hack/ci/scripts-v2/integration-test-gardener.sh" ${{ inputs.test_make_target }}
     - name: Gather deployment logs
       shell: bash

--- a/.github/actions/e2e-test-k3d/action.yaml
+++ b/.github/actions/e2e-test-k3d/action.yaml
@@ -7,6 +7,9 @@ inputs:
   test_make_target:
     description: 'Make target for integration tests to run'
     default: 'istio-test-integration'
+  operator-version:
+    description: 'Version of the operator image'
+    required: true
   agents:
     description: 'Number of k3d agents created'
     required: true
@@ -27,6 +30,8 @@ runs:
         servers-memory: ${{ inputs.servers-memory }}
     - name: Run integration tests
       shell: bash
+      env:
+        OPERATOR_VERSION: ${{ inputs.operator-version }}
       run: |    
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           k3d image import ${{ inputs.operator-image-name }}

--- a/.github/actions/integration-test/action.yaml
+++ b/.github/actions/integration-test/action.yaml
@@ -8,9 +8,9 @@ inputs:
   test_make_target:
     description: 'Make target for integration tests to run'
     default: 'istio-test-integration'
-  version:
+  operator-version:
     description: 'Version of the operator image'
-    default: 'dev'
+    required: true
   agents:
     description: 'Number of k3d agents created'
     required: true
@@ -32,7 +32,7 @@ runs:
     - name: Run integration tests
       shell: bash
       env:
-        VERSION: ${{ inputs.version }}
+        OPERATOR_VERSION: ${{ inputs.operator-version }}
       run: |    
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           k3d image import ${{ inputs.operator-image-name }}

--- a/.github/actions/integration-test/action.yaml
+++ b/.github/actions/integration-test/action.yaml
@@ -8,6 +8,9 @@ inputs:
   test_make_target:
     description: 'Make target for integration tests to run'
     default: 'istio-test-integration'
+  version:
+    description: 'Version of the operator image'
+    default: 'dev'
   agents:
     description: 'Number of k3d agents created'
     required: true
@@ -28,6 +31,8 @@ runs:
         servers-memory: ${{ inputs.servers-memory }}
     - name: Run integration tests
       shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
       run: |    
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           k3d image import ${{ inputs.operator-image-name }}

--- a/.github/actions/k8s-compatibility-test-aws/action.yaml
+++ b/.github/actions/k8s-compatibility-test-aws/action.yaml
@@ -16,6 +16,10 @@ inputs:
   test_make_target:
     description: "Make target for integration tests to run"
     default: 'test-integration'
+  operator_version:
+    description: 'Version of the operator image'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -43,6 +47,7 @@ runs:
       shell: bash
       env:
         IMG: ${{ inputs.manager_image }}
+        OPERATOR_VERSION: ${{ inputs.operator_version }}
         CLUSTER_KUBECONFIG: "${{ github.workspace }}/${{ env.CLUSTER_NAME }}_kubeconfig.yaml"
       run: EXPORT_RESULT=true "${{ github.workspace }}/hack/ci/scripts-v2/integration-test-gardener.sh" ${{ inputs.test_make_target }}
     - name: Check deprecations

--- a/.github/actions/k8s-compatibility-test/action.yaml
+++ b/.github/actions/k8s-compatibility-test/action.yaml
@@ -7,6 +7,10 @@ inputs:
   test_make_target:
     description: 'Make target for integration tests to run'
     default: 'istio-test-integration'
+  operator_version:
+    description: 'Version of the operator image'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -18,6 +22,8 @@ runs:
       with:
         k3s-version: "1.32.3"
     - name: Run integration tests
+      env:
+        OPERATOR_VERSION: ${{ inputs.operator_version }}
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           k3d image import ${{ inputs.operator_image_name }}

--- a/.github/actions/upgrade-integration-test/action.yaml
+++ b/.github/actions/upgrade-integration-test/action.yaml
@@ -7,6 +7,10 @@ inputs:
   target_branch:
     description: 'Target branch'
     required: true
+  operator-version:
+    description: 'Version of the operator image'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -18,6 +22,8 @@ runs:
       with:
         k3s-version: "1.31.7"
     - name: Run upgrade integration test
+      env:
+        OPERATOR_VERSION: ${{ inputs.operator-version }}
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           k3d image import ${{ inputs.operator-image-name }}

--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -14,6 +14,10 @@ on:
         description: Image used to run tests
         required: true
         type: string
+      operator_version:
+        description: Version of the operator image
+        required: true
+        type: string
 
 jobs:
   istio-upgrade-integration-test-aws:
@@ -36,6 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAKE_TEST_TARGET: "istio-upgrade-integration-test"
           TARGET_BRANCH: ${{github.ref_name}}
+          OPERATOR_VERSION: "${{ inputs.operator_version }}"
           GARDENER_KUBECONFIG: "/home/runner/work/istio/istio/gardener_kubeconfig.yaml"
           GARDENER_PROJECT_NAME: "goats"
           GARDENER_PROVIDER_SECRET_NAME: "aws-gardener-access"
@@ -59,6 +64,7 @@ jobs:
         with:
           operator-image-name: ${{ inputs.image }}
           target_branch: ${{ github.ref_name }}
+          operator-version: ${{ inputs.operator_version }}
 
   istio-integration-test:
     name: Istio integration test
@@ -74,6 +80,7 @@ jobs:
       - uses: ./.github/actions/integration-test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPERATOR_VERSION: "${{ inputs.operator_version }}"
         with:
           test_make_target: ${{ matrix.test_make_target }}
           operator-image-name: "${{ inputs.image }}"
@@ -114,6 +121,7 @@ jobs:
           SCALER_MAX: 20
           SCALER_MIN: 3
           MAKE_TEST_TARGET: ${{ matrix.test_make_target }}
+          OPERATOR_VERSION: "${{ inputs.operator_version }}"
 
   istio-integration-aws-specific:
     name: Istio integration test AWS specific
@@ -144,6 +152,7 @@ jobs:
           DISK_TYPE: "gp2"
           SCALER_MAX: 3
           SCALER_MIN: 3
+          OPERATOR_VERSION: "${{ inputs.operator_version }}"
 
   istio-integration-gcp-specific:
     name: Istio integration test GCP specific
@@ -174,6 +183,8 @@ jobs:
           DISK_TYPE: "pd-standard"
           SCALER_MAX: 20
           SCALER_MIN: 3
+          OPERATOR_VERSION: "${{ inputs.operator_version }}"
+
 
   istio-e2e-aws:
     name: Istio E2E test AWS
@@ -195,3 +206,4 @@ jobs:
           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
           gardener_provider: aws
           test_make_target: ${{ matrix.test_make_target }}
+          operator_version: ${{ inputs.operator_version }}

--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -80,9 +80,9 @@ jobs:
       - uses: ./.github/actions/integration-test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPERATOR_VERSION: "${{ inputs.operator_version }}"
         with:
           test_make_target: ${{ matrix.test_make_target }}
+          operator-version: ${{ inputs.operator_version }}
           operator-image-name: "${{ inputs.image }}"
           servers-memory: "16"
           agents: 2
@@ -184,7 +184,6 @@ jobs:
           SCALER_MAX: 20
           SCALER_MIN: 3
           OPERATOR_VERSION: "${{ inputs.operator_version }}"
-
 
   istio-e2e-aws:
     name: Istio E2E test AWS

--- a/.github/workflows/call-pull-e2e.yaml
+++ b/.github/workflows/call-pull-e2e.yaml
@@ -5,6 +5,11 @@ permissions:
   
 on:
   workflow_call:
+    inputs:
+      operator_version:
+        description: 'Operator version'
+        required: true
+        type: string
 
 jobs:
   istio-e2e-test-k3d:

--- a/.github/workflows/call-pull-e2e.yaml
+++ b/.github/workflows/call-pull-e2e.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           test_make_target: ${{ matrix.test_make_target }}
           operator-image-name: "istio-manager:PR-${{github.event.number}}"
+          operator-version: "PR-${{github.event.number}}"
           servers-memory: "16"
           agents: 2
 
@@ -47,5 +48,6 @@ jobs:
         with:
           test_make_target: "evaluation-integration-test"
           operator-image-name: "istio-manager:PR-${{github.event.number}}"
+          operator-version: "PR-${{github.event.number}}"
           servers-memory: "4"
           agents: 0

--- a/.github/workflows/post-main-workflow.yaml
+++ b/.github/workflows/post-main-workflow.yaml
@@ -64,6 +64,7 @@ jobs:
         with:
           operator-image-name: "europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:${{github.sha}}"
           target_branch: ${{ github.ref_name }}
+          operator-version: ${{ github.ref_name }}
 
   istio-upgrade-test-aws:
     name: Istio upgrade integration test AWS
@@ -83,6 +84,7 @@ jobs:
           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
           gardener_provider: aws
           test_make_target: "istio-upgrade-integration-test"
+          operator_version: ${{ github.ref_name }}
 
   istio-e2e-test-k3d:
     name: Istio E2E test K3D
@@ -101,6 +103,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           test_make_target: ${{ matrix.test_make_target }}
+          operator-version: ${{ github.ref_name }}
           operator-image-name: "europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:${{github.sha}}"
           servers-memory: "16"
           agents: 2
@@ -126,6 +129,7 @@ jobs:
           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
           gardener_provider: gcp
           test_make_target: ${{ matrix.test_make_target }}
+          operator_version: ${{ github.ref_name }}
 
   istio-e2e-aws-specific:
     name: Istio E2E test AWS specific
@@ -144,6 +148,7 @@ jobs:
           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
           gardener_provider: aws
           test_make_target: aws-integration-test
+          operator_version: ${{ github.ref_name }}
 
   istio-e2e-gcp-specific:
     name: Istio E2E test GCP specific
@@ -162,6 +167,7 @@ jobs:
           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
           gardener_provider: gcp
           test_make_target: gcp-integration-test
+          operator_version: ${{ github.ref_name }}
 
   istio-e2e-aws:
     name: Istio E2E test AWS
@@ -184,6 +190,7 @@ jobs:
           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
           gardener_provider: aws
           test_make_target: ${{ matrix.test_make_target }}
+          operator_version: ${{ github.ref_name }}
 
   slack_failed_notification:
     name: Slack Notification

--- a/.github/workflows/pull-build-push.yaml
+++ b/.github/workflows/pull-build-push.yaml
@@ -31,5 +31,6 @@ jobs:
       - uses: ./.github/actions/build-manager-image
         with:
           operator-image-name: "europe-central2-docker.pkg.dev/sap-se-cx-kyma-goat/istio/istio-manager:PR-${{github.event.number}}"
+          operator-version: "PR-${{github.event.number}}"
           push-image: 'true'
           push-sa-key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -34,6 +34,7 @@ jobs:
       - uses: ./.github/actions/build-manager-image
         with:
           operator-image-name: "istio-manager:PR-${{github.event.number}}"
+          operator-version: "PR-${{github.event.number}}"
 
   lint-unit-tests:
     name: Dispatch lint & unit test

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -45,6 +45,8 @@ jobs:
     name: Dispatch E2E tests
     needs: [build-image]
     uses: ./.github/workflows/call-pull-e2e.yaml
+    with:
+      operator_version: "dev"
     if: github.event.pull_request.draft == false
     secrets: inherit
 
@@ -61,6 +63,7 @@ jobs:
         with:
           operator-image-name: "istio-manager:PR-${{github.event.number}}"
           target_branch: ${{ github.base_ref }}
+          operator-version: "dev"
 
   verify-pins:
     name: Dispatch verify-commit-pins

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -47,7 +47,7 @@ jobs:
     needs: [build-image]
     uses: ./.github/workflows/call-pull-e2e.yaml
     with:
-      operator_version: "dev"
+      operator_version: "PR-${{github.event.number}}"
     if: github.event.pull_request.draft == false
     secrets: inherit
 
@@ -64,7 +64,7 @@ jobs:
         with:
           operator-image-name: "istio-manager:PR-${{github.event.number}}"
           target_branch: ${{ github.base_ref }}
-          operator-version: "dev"
+          operator-version: "PR-${{github.event.number}}"
 
   verify-pins:
     name: Dispatch verify-commit-pins

--- a/.github/workflows/release-istio-2.yaml
+++ b/.github/workflows/release-istio-2.yaml
@@ -80,6 +80,7 @@ jobs:
     uses: ./.github/workflows/call-integration-tests.yaml
     with:
       image: "europe-docker.pkg.dev/kyma-project/prod/istio/releases/istio-manager:${{ needs.check-prerequisites.outputs.current_release }}"
+      operator_version: ${{ needs.check-prerequisites.outputs.current_release }}
     secrets: inherit
 
   create-draft:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM golang:1.24.5-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GO_BUILD_TAGS
-ARG VERSION=dev
+ARG VERSION
 
 WORKDIR /istio-build
 # Copy the Go Modules manifests
@@ -26,7 +26,7 @@ COPY cmd/ cmd/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags ${GO_BUILD_TAGS} -ldflags="-s -w -X github.com/kyma-project/istio/operator/internal/resources.version=${VERSION}" -o manager main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "${GO_BUILD_TAGS}" -ldflags="-s -w -X github.com/kyma-project/istio/operator/internal/resources.version=${VERSION}" -o manager main.go
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o istio_install cmd/istio-install/main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM golang:1.24.5-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GO_BUILD_TAGS
-ARG VERSION
+ARG VERSION=dev
 
 WORKDIR /istio-build
 # Copy the Go Modules manifests

--- a/docs/release-notes/1.21.0.md
+++ b/docs/release-notes/1.21.0.md
@@ -7,3 +7,5 @@ as [Istio 1.26.0 release announcement](https://istio.io/latest/news/releases/1.2
 ## Fixed Bugs
 
 - We've fixed a bug where the `proxy-protocol` EnvoyFilter applied by the Istio module on AWS clusters with ELB load balancers was incorrectly detected as a user resource. This resulted in the Istio custom resource being set to the `Warning` state. See [#1491](https://github.com/kyma-project/istio/issues/1491).
+- We've fixed a bug where labels of the Istio managed resources were not correctly reconciled. See [#1523](https://github.com/kyma-project/istio/issues/1523).
+- We've fixed a bug where `app.kubernetes.io/version` label was not set to the proper version in the managed resources. See [#1523](https://github.com/kyma-project/istio/issues/1523).

--- a/docs/release-notes/1.21.0.md
+++ b/docs/release-notes/1.21.0.md
@@ -8,4 +8,4 @@ as [Istio 1.26.0 release announcement](https://istio.io/latest/news/releases/1.2
 
 - We've fixed a bug where the `proxy-protocol` EnvoyFilter applied by the Istio module on AWS clusters with ELB load balancers was incorrectly detected as a user resource. This resulted in the Istio custom resource being set to the `Warning` state. See [#1491](https://github.com/kyma-project/istio/issues/1491).
 - We've fixed a bug where labels of the Istio managed resources were not correctly reconciled. See [#1523](https://github.com/kyma-project/istio/issues/1523).
-- We've fixed a bug where `app.kubernetes.io/version` label was not set to the proper version in the managed resources. See [#1523](https://github.com/kyma-project/istio/issues/1523).
+- We've fixed a bug where the `app.kubernetes.io/version` label was not set to the proper version in the managed resources. See [#1523](https://github.com/kyma-project/istio/issues/1523).

--- a/internal/reconciliations/istioresources/proxy_protocol_envoy_filter_test.go
+++ b/internal/reconciliations/istioresources/proxy_protocol_envoy_filter_test.go
@@ -27,14 +27,14 @@ var _ = Describe("Apply", func() {
 		sample := NewProxyProtocolEnvoyFilter(client, false)
 
 		//when
-		changed, err := sample.reconcile(context.TODO(), client, owner, templateValues)
+		changed, err := sample.reconcile(context.Background(), client, owner, templateValues)
 
 		//then
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(changed).To(Equal(controllerutil.OperationResultCreated))
 
 		var s networkingv1alpha3.EnvoyFilterList
-		listErr := client.List(context.TODO(), &s)
+		listErr := client.List(context.Background(), &s)
 		Expect(listErr).To(Not(HaveOccurred()))
 		Expect(s.Items).To(HaveLen(1))
 
@@ -53,23 +53,32 @@ var _ = Describe("Apply", func() {
 
 	It("should return not changed if no change was applied", func() {
 		//given
-		var p networkingv1alpha3.EnvoyFilter
-		err := yaml.Unmarshal(proxyProtocolEnvoyFilter, &p)
-		Expect(err).To(Not(HaveOccurred()))
-
-		client := createFakeClient(&p)
-
+		client := createFakeClient()
 		sample := NewProxyProtocolEnvoyFilter(client, false)
 
 		//when
-		changed, err := sample.reconcile(context.TODO(), client, owner, templateValues)
+		changed, err := sample.reconcile(context.Background(), client, owner, templateValues)
+		// first reconciliation required because we add app.kubernetes.io/version in runtime, so it's not present in the yaml
+		Expect(err).To(Not(HaveOccurred()))
+		Expect(changed).To(Equal(controllerutil.OperationResultCreated))
 
-		//then
+		var s networkingv1alpha3.EnvoyFilterList
+		listErr := client.List(context.Background(), &s)
+		Expect(listErr).To(Not(HaveOccurred()))
+		Expect(s.Items).To(HaveLen(1))
+
+		Expect(s.Items[0].Annotations).To(Not(BeNil()))
+		Expect(s.Items[0].Annotations[resources.DisclaimerKey]).To(Not(BeNil()))
+
+		// then
+		// we check in the second reconciliation that nothing changed
+		sample = NewProxyProtocolEnvoyFilter(client, false)
+		changed, err = sample.reconcile(context.Background(), client, owner, templateValues)
+
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(changed).To(Equal(controllerutil.OperationResultNone))
 
-		var s networkingv1alpha3.EnvoyFilterList
-		listErr := client.List(context.TODO(), &s)
+		listErr = client.List(context.Background(), &s)
 		Expect(listErr).To(Not(HaveOccurred()))
 		Expect(s.Items).To(HaveLen(1))
 
@@ -89,14 +98,14 @@ var _ = Describe("Apply", func() {
 		sample := NewProxyProtocolEnvoyFilter(client, false)
 
 		//when
-		changed, err := sample.reconcile(context.TODO(), client, owner, templateValues)
+		changed, err := sample.reconcile(context.Background(), client, owner, templateValues)
 
 		//then
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(changed).To(Equal(controllerutil.OperationResultUpdated))
 
 		var s networkingv1alpha3.EnvoyFilterList
-		listErr := client.List(context.TODO(), &s)
+		listErr := client.List(context.Background(), &s)
 		Expect(listErr).To(Not(HaveOccurred()))
 		Expect(s.Items).To(HaveLen(1))
 

--- a/internal/resources/disclaimer_annotation_test.go
+++ b/internal/resources/disclaimer_annotation_test.go
@@ -3,6 +3,7 @@ package resources_test
 import (
 	"context"
 	"github.com/kyma-project/istio/operator/internal/resources"
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -68,6 +69,8 @@ func createFakeClient(objects ...ctrlClient.Object) ctrlClient.Client {
 	err = securityv1.AddToScheme(scheme.Scheme)
 	Expect(err).ShouldNot(HaveOccurred())
 	err = networkingv1alpha3.AddToScheme(scheme.Scheme)
+	Expect(err).ShouldNot(HaveOccurred())
+	err = v1alpha3.AddToScheme(scheme.Scheme)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objects...).Build()

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -90,7 +89,9 @@ func createOrUpdateResource(
 ) (unstructured.Unstructured, controllerutil.OperationResult, error) {
 	spec, specExist := resource.Object["spec"]
 	data, dataExist := resource.Object["data"]
+	labels := resource.GetLabels()
 	result, err := controllerutil.CreateOrUpdate(ctx, k8sClient, &resource, func() error {
+		resource.SetLabels(labels)
 		if dataExist {
 			resource.Object["data"] = data
 		}

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -91,7 +91,15 @@ func createOrUpdateResource(
 	data, dataExist := resource.Object["data"]
 	labels := resource.GetLabels()
 	result, err := controllerutil.CreateOrUpdate(ctx, k8sClient, &resource, func() error {
-		resource.SetLabels(labels)
+		l := resource.GetLabels()
+		if l == nil {
+			l = make(map[string]string)
+		}
+		for k, v := range labels {
+			l[k] = v
+		}
+		resource.SetLabels(l)
+
 		if dataExist {
 			resource.Object["data"] = data
 		}

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -103,7 +103,9 @@ var _ = Describe("Apply", func() {
 		Expect(ok).To(BeTrue())
 	})
 
-	It("should update resource with labels if some has been added", func() {
+	It("should append resource with labels if some has been added", func() {
+		testLabelKey := "test-label"
+		testLabelValue := "test-value"
 		var ef networkingv1alpha3.EnvoyFilter
 		Expect(yaml.Unmarshal(resourceBeforeLabels, &ef)).Should(Succeed())
 		k8sClient := createFakeClient(&ef)
@@ -112,6 +114,9 @@ var _ = Describe("Apply", func() {
 		um, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&ef)
 		unstr := unstructured.Unstructured{Object: um}
 		Expect(err).ToNot(HaveOccurred())
+		// old label that should be present
+		Expect(unstr.GetLabels()).To(HaveKeyWithValue(testLabelKey, testLabelValue))
+		// added labels that should not be present yet
 		Expect(unstr.GetLabels()).To(Not(HaveKeyWithValue("kyma-project.io/module", "istio")))
 		Expect(unstr.GetLabels()).To(Not(HaveKeyWithValue("app.kubernetes.io/component", "operator")))
 		Expect(unstr.GetLabels()).To(Not(HaveKeyWithValue("app.kubernetes.io/part-of", "istio")))
@@ -129,6 +134,9 @@ var _ = Describe("Apply", func() {
 		um, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&ef)
 		unstr = unstructured.Unstructured{Object: um}
 		Expect(err).ToNot(HaveOccurred())
+		// old label that should be preserved
+		Expect(unstr.GetLabels()).To(HaveKeyWithValue(testLabelKey, testLabelValue))
+		//  new labels that should be added
 		Expect(unstr.GetLabels()).To(HaveKeyWithValue("kyma-project.io/module", "istio"))
 		Expect(unstr.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/component", "operator"))
 		Expect(unstr.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/part-of", "istio"))

--- a/internal/resources/test_files/resource_after_labels.yaml
+++ b/internal/resources/test_files/resource_after_labels.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: proxy-protocol
+  namespace: istio-system
+  labels:
+    kyma-project.io/module: istio
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/name: istio-operator
+    app.kubernetes.io/instance: istio-operator-default
+spec:
+  configPatches:
+    - applyTo: LISTENER_FILTER
+      patch:
+        operation: INSERT_FIRST
+        value:
+          name: proxy_protocol
+          typed_config:
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol"
+  workloadSelector:
+    labels:
+      istio: ingressgateway

--- a/internal/resources/test_files/resource_before_labels.yaml
+++ b/internal/resources/test_files/resource_before_labels.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: proxy-protocol
+  namespace: istio-system
+spec:
+  configPatches:
+    - applyTo: LISTENER_FILTER
+      patch:
+        operation: INSERT_FIRST
+        value:
+          name: proxy_protocol
+          typed_config:
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol"
+  workloadSelector:
+    labels:
+      istio: ingressgateway

--- a/internal/resources/test_files/resource_before_labels.yaml
+++ b/internal/resources/test_files/resource_before_labels.yaml
@@ -3,6 +3,8 @@ kind: EnvoyFilter
 metadata:
   name: proxy-protocol
   namespace: istio-system
+  labels:
+    test-label: test-value
 spec:
   configPatches:
     - applyTo: LISTENER_FILTER

--- a/tests/integration/features/installation-suite/install.feature
+++ b/tests/integration/features/installation-suite/install.feature
@@ -56,6 +56,7 @@ Feature: Installing and uninstalling Istio module
     Given Istio CR "istio-sample" from "istio_cr_template" is applied in namespace "kyma-system"
     When Istio CR "istio-sample" in namespace "kyma-system" has status "Ready"
     And "PeerAuthentication" "default" in namespace "istio-system" is "present"
+    And "PeerAuthentication" "default" in namespace "istio-system" has proper value in app.kubernetes.io/version label
     When "Istio CR" "istio-sample" in namespace "kyma-system" is deleted
     Then "Istio CR" is not present on cluster
     And Namespace "istio-system" is "not present"

--- a/tests/integration/scenario.go
+++ b/tests/integration/scenario.go
@@ -3,6 +3,8 @@ package integration
 import (
 	"github.com/cucumber/godog"
 	"github.com/kyma-project/istio/operator/tests/integration/steps"
+	"github.com/kyma-project/istio/operator/tests/integration/testsupport"
+	"log"
 )
 
 func initScenario(ctx *godog.ScenarioContext) {
@@ -10,6 +12,12 @@ func initScenario(ctx *godog.ScenarioContext) {
 	ctx.After(testObjectsTearDown)
 	ctx.After(istioCrTearDown)
 	t := steps.TemplatedIstioCr{}
+
+	err := testsupport.EnvironmentVariables()
+	if err != nil {
+		panic("Failed to set environment variables: " + err.Error())
+	}
+	log.Printf("initializing tests with Istio Module version: %s", testsupport.GetOperatorVersion())
 
 	// This structure holds all Tester instances
 	// every test scenario should have an own instance to allow parallel execution
@@ -69,4 +77,5 @@ func initScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^Application "([^"]*)" in namespace "([^"]*)" has required version of proxy as an init container$`, steps.ApplicationHasRequiredVersionInitContainerWithIstioProxy)
 	ctx.Step(`^There are continuous requests to host "([^"]*)" and path "([^"]*)"`, zd.StartZeroDowntimeTest)
 	ctx.Step(`^All continuous requests should succeed`, zd.FinishZeroDowntimeTests)
+	ctx.Step(`^"([^"]*)" "([^"]*)" in namespace "([^"]*)" has proper value in app.kubernetes.io/version label$`, steps.ManagedResourceHasOperatorVersionLabelWithProperValue)
 }

--- a/tests/integration/scenario.go
+++ b/tests/integration/scenario.go
@@ -13,7 +13,7 @@ func initScenario(ctx *godog.ScenarioContext) {
 	ctx.After(istioCrTearDown)
 	t := steps.TemplatedIstioCr{}
 
-	err := testsupport.EnvironmentVariables()
+	err := testsupport.LoadEnvironmentVariables()
 	if err != nil {
 		panic("Failed to set environment variables: " + err.Error())
 	}

--- a/tests/integration/testsupport/environments.go
+++ b/tests/integration/testsupport/environments.go
@@ -15,7 +15,10 @@ var requiredEnvs = []EnvVar{
 }
 
 func EnvironmentVariables() error {
-	ciMode := os.Getenv("GITHUB_WORKFLOW")
+	// env variable should always be set to true in the workflow
+	// according to the documentation: https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
+	// it is present in the Github Actions workflows
+	ciMode := os.Getenv("CI")
 	if ciMode != "true" {
 		err := setDefaultEnvs()
 		if err != nil {

--- a/tests/integration/testsupport/environments.go
+++ b/tests/integration/testsupport/environments.go
@@ -2,6 +2,7 @@ package testsupport
 
 import (
 	"fmt"
+	"log"
 	"os"
 )
 
@@ -20,6 +21,7 @@ func LoadEnvironmentVariables() error {
 	// it is present in the Github Actions workflows
 	ciMode := os.Getenv("CI")
 	if ciMode != "true" {
+		log.Println("CI environment variable is not set to true, setting default environment variables")
 		err := setDefaultEnvs()
 		if err != nil {
 			return err

--- a/tests/integration/testsupport/environments.go
+++ b/tests/integration/testsupport/environments.go
@@ -14,7 +14,7 @@ var requiredEnvs = []EnvVar{
 	{"OPERATOR_VERSION", "dev"},
 }
 
-func EnvironmentVariables() error {
+func LoadEnvironmentVariables() error {
 	// env variable should always be set to true in the workflow
 	// according to the documentation: https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
 	// it is present in the Github Actions workflows

--- a/tests/integration/testsupport/environments.go
+++ b/tests/integration/testsupport/environments.go
@@ -1,0 +1,57 @@
+package testsupport
+
+import (
+	"fmt"
+	"os"
+)
+
+type EnvVar struct {
+	Name    string
+	Default string
+}
+
+var requiredEnvs = []EnvVar{
+	{"OPERATOR_VERSION", "dev"},
+}
+
+func EnvironmentVariables() error {
+	ciMode := os.Getenv("GITHUB_WORKFLOW")
+	if ciMode != "true" {
+		err := setDefaultEnvs()
+		if err != nil {
+			return err
+		}
+	}
+
+	err := validateEnvs()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetOperatorVersion() string {
+	return os.Getenv("OPERATOR_VERSION")
+}
+
+func setDefaultEnvs() error {
+	for _, env := range requiredEnvs {
+		err := os.Setenv(env.Name, env.Default)
+		if err != nil {
+			return fmt.Errorf("failed to set default environment variable: " + env.Name + " with error: " + err.Error())
+		}
+	}
+
+	return nil
+}
+
+func validateEnvs() error {
+	for _, env := range requiredEnvs {
+		if os.Getenv(env.Name) == "" {
+			return fmt.Errorf("required environment variable is not set: " + env.Name + ". Please set it to run the tests.")
+		}
+	}
+
+	return nil
+}

--- a/tests/integration/testsupport/environments.go
+++ b/tests/integration/testsupport/environments.go
@@ -39,7 +39,7 @@ func setDefaultEnvs() error {
 	for _, env := range requiredEnvs {
 		err := os.Setenv(env.Name, env.Default)
 		if err != nil {
-			return fmt.Errorf("failed to set default environment variable: " + env.Name + " with error: " + err.Error())
+			return fmt.Errorf("failed to set default environment variable: %s with error: %s", env.Name, err.Error())
 		}
 	}
 
@@ -49,7 +49,7 @@ func setDefaultEnvs() error {
 func validateEnvs() error {
 	for _, env := range requiredEnvs {
 		if os.Getenv(env.Name) == "" {
-			return fmt.Errorf("required environment variable is not set: " + env.Name + ". Please set it to run the tests.")
+			return fmt.Errorf("required environment variable is not set: %s. Please set it to run the tests", env.Name)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix labels reconciliation in resource manager - now it appends new labels if we introduce them in yaml definitions
- Fix `app.kubernetes.io/version` label which was broken due to build system issue - go build empty `-tags` argument caused `-ldflas` flag being treated as the argument for `-tags`
- introduced regression e2e test for `app.kubernetes.io/version` label

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#1523 