### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/workflows/post-main-workflow.yaml
+++ b/.github/workflows/post-main-workflow.yaml
@@ -36,7 +36,6 @@ jobs:
       build-args: |
         VERSION=${{ github.ref_name }}
       tags: "${{ github.sha }}"
-      build-engine: buildx
 
   build-experimental-image:
     name: Build manager image - experimental
@@ -50,7 +49,6 @@ jobs:
         VERSION=${{ github.ref_name }}-experimental
         GO_BUILD_TAGS=experimental
       tags: "${{ github.sha }}-experimental"
-      build-engine: buildx
 
   istio-upgrade-test-k3d:
     name: Istio upgrade integration test K3D

--- a/.github/workflows/release-create-release.yaml
+++ b/.github/workflows/release-create-release.yaml
@@ -40,7 +40,6 @@ jobs:
       build-args: |
         VERSION=${{ github.event.inputs.version }}
       tags: "${{ github.event.inputs.version }}"
-      build-engine: buildx
 
   build-image-experimental:
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -53,7 +52,6 @@ jobs:
         VERSION=${{ github.event.inputs.version }}-experimental
         GO_BUILD_TAGS=experimental
       tags: "${{ github.event.inputs.version }}-experimental"
-      build-engine: buildx
 
   unit-tests:
     uses: ./.github/workflows/call-unit-lint.yaml

--- a/.github/workflows/release-istio-2.yaml
+++ b/.github/workflows/release-istio-2.yaml
@@ -57,7 +57,6 @@ jobs:
       build-args: |
         VERSION=${{ needs.check-prerequisites.outputs.current_release }}
       tags: "${{ needs.check-prerequisites.outputs.current_release }}"
-      build-engine: buildx
 
   build-image-experimental:
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -70,7 +69,6 @@ jobs:
         VERSION=${{ needs.check-prerequisites.outputs.current_release }}-experimental
         GO_BUILD_TAGS=experimental
       tags: "${{ needs.check-prerequisites.outputs.current_release }}-experimental"
-      build-engine: buildx
 
   unit-tests:
     uses: ./.github/workflows/call-unit-lint.yaml


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.