### PR TITLE
docs: fix link to Gardener certificates troubleshooting guide

### DIFF
--- a/docs/user/troubleshooting/03-10-503-no-access.md
+++ b/docs/user/troubleshooting/03-10-503-no-access.md
@@ -62,6 +62,6 @@ If the restart doesn't help, follow these steps:
 
 2. If the ports `80` and `443` are not used, check the logs of the `istio-proxy` container for errors related to certificates. To do this, click **View Logs**.
 
-3. To make sure that a corrupted certificate is regenerated, verify if the **spec.enableKymaGateway** field of your APIGateway custom resource is set to `true`. If you are running Kyma provisioned through Gardener, follow the [Issues with Certificates on Gardener](https://kyma-project.io/docs/kyma/latest/04-operation-guides/troubleshooting/security/sec-01-certificates-gardener/) troubleshooting guide instead.
+3. To make sure that a corrupted certificate is regenerated, verify if the **spec.enableKymaGateway** field of your APIGateway custom resource is set to `true`. If you are running Kyma provisioned through Gardener, follow the [Issues with Certificates on Gardener](https://kyma-project.io/04-operation-guides/troubleshooting/security/sec-01-certificates-gardener.html#issues-with-certificates-on-gardener) troubleshooting guide instead.
 
 <!-- tabs:end -->


### PR DESCRIPTION
Updated the link to the troubleshooting guide for Gardener.

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixed a broken link

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make generate-manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
