### PR TITLE
Update docs of XFCC field.

### DIFF
--- a/api/v1alpha2/istio_structs.go
+++ b/api/v1alpha2/istio_structs.go
@@ -13,7 +13,8 @@ type Config struct {
 	NumTrustedProxies *int `json:"numTrustedProxies,omitempty"`
 
 	// Defines the strategy of handling the **X-Forwarded-Client-Cert** header only by the gateway proxies.
-	// This setting controls how the client attributes are retrieved from the incoming traffic by the gateway proxy and propagated to the upstream services in the cluster.
+	// This setting controls how the gateway proxy retrieves client attributes from incoming traffic and propagates them to upstream services in the cluster.
+	// Gateway proxies in Istio module are represented by the Istio Ingress Gateway and Istio Egress Gateway.
 	// The default behavior for gateway proxies is "SANITIZE_SET".
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=APPEND_FORWARD;SANITIZE_SET;SANITIZE;ALWAYS_FORWARD_ONLY;FORWARD_ONLY
@@ -40,7 +41,7 @@ type Config struct {
 	TrustDomain *string `json:"trustDomain,omitempty"`
 }
 
-// Defines how proxy handles the x-forwarded-client-cert (XFCC) of the HTTP header.
+// Defines how the proxy handles the **X-Forwarded-Client-Cert** (XFCC) of the HTTP header.
 // XFCC is a proxy header that indicates certificate information of part or all of the clients or proxies that a request has passed through on its route from the client to the server.
 type XFCCStrategy string
 

--- a/config/crd/bases/operator.kyma-project.io_istios.yaml
+++ b/config/crd/bases/operator.kyma-project.io_istios.yaml
@@ -1492,7 +1492,8 @@ spec:
                   forwardClientCertDetails:
                     description: |-
                       Defines the strategy of handling the **X-Forwarded-Client-Cert** header only by the gateway proxies.
-                      This setting controls how the client attributes are retrieved from the incoming traffic by the gateway proxy and propagated to the upstream services in the cluster.
+                      This setting controls how the gateway proxy retrieves client attributes from incoming traffic and propagates them to upstream services in the cluster.
+                      Gateway proxies in Istio module are represented by the Istio Ingress Gateway and Istio Egress Gateway.
                       The default behavior for gateway proxies is "SANITIZE_SET".
                     enum:
                     - APPEND_FORWARD

--- a/docs/contributor/adr/0012-support-for-forward-client-cert-details.md
+++ b/docs/contributor/adr/0012-support-for-forward-client-cert-details.md
@@ -9,7 +9,7 @@ Accepted
 To ensure that the client certificate details can be forwarded to the backend
 services when mTLS is used to secure the Istio ingress gateway, 
 it is essential to extend the Istio CustomResourceDefinitions (CRDs) to include a new field named **forwardClientCertDetails**.
-This field allows to configure the strategy for forwarding client certificate information in the **X-Forwarded-Client-Cert** header for gateway proxies. This setting controls how the client attributes are retrieved from the incoming traffic by the gateway proxy and propagated to the upstream services in the cluster. By default, upstream Istio uses the `SANITIZE_SET` strategy for the gateway proxy, which resets the XFCC header with the client certificate information and sends it to the next hop.
+This field allows to configure the strategy for forwarding client certificate information in the **X-Forwarded-Client-Cert** header for gateway proxies. This setting controls how the gateway proxy retrieves client attributes from incoming traffic and propagates them to upstream services in the cluster. By default, upstream Istio uses the `SANITIZE_SET` strategy for the gateway proxy, which resets the XFCC header with the client certificate information and sends it to the next hop. Gateway proxies in Istio module are represented by the Istio Ingress Gateway and Istio Egress Gateway.
 For more information about the available strategies, see the official [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#enum-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-forwardclientcertdetails) and [Istio documentation](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#Topology-forward_client_cert_details).
 
 ## Decision
@@ -26,5 +26,5 @@ The field will be of type string and will accept the following values:
 
 The field will not have a default value specified in the CRD schema, allowing users to explicitly set it based on their requirements.
 The default value defined by Istio upstream for this field is `SANITIZE_SET` for gateway proxies, ensuring that, by default,
-the XFCC header is reset and sent to the next hop, unless explicitly configured otherwise in Istio module CR.
+the XFCC header is reset and sent to the next hop, unless explicitly configured otherwise in the Istio module's CR.
 

--- a/docs/user/04-00-istio-custom-resource.md
+++ b/docs/user/04-00-istio-custom-resource.md
@@ -135,7 +135,7 @@ Appears in:
 | Field | Description | Validation |
 | --- | --- | --- |
 | **numTrustedProxies** <br /> integer | Defines the number of trusted proxies deployed in front of the Istio gateway proxy. | Maximum: 4.294967295e+09 <br />Minimum: 0 <br /> |
-| **forwardClientCertDetails** <br /> [XFCCStrategy](#xfccstrategy) | Defines the strategy of handling the **X-Forwarded-Client-Cert** header only by the gateway proxies.<br />This setting controls how the client attributes are retrieved from the incoming traffic by the gateway proxy and propagated to the upstream services in the cluster.<br />The default behavior for gateway proxies is "SANITIZE_SET". | Enum: [APPEND_FORWARD SANITIZE_SET SANITIZE ALWAYS_FORWARD_ONLY FORWARD_ONLY] <br />Optional <br /> |
+| **forwardClientCertDetails** <br /> [XFCCStrategy](#xfccstrategy) | Defines the strategy of handling the **X-Forwarded-Client-Cert** header only by the gateway proxies.<br />This setting controls how the gateway proxy retrieves client attributes from incoming traffic and propagates them to upstream services in the cluster.<br />Gateway proxies in Istio module are represented by the Istio Ingress Gateway and Istio Egress Gateway.<br />The default behavior for gateway proxies is "SANITIZE_SET". | Enum: [APPEND_FORWARD SANITIZE_SET SANITIZE ALWAYS_FORWARD_ONLY FORWARD_ONLY] <br />Optional <br /> |
 | **authorizers** <br /> [Authorizer](#authorizer) array | Defines a list of external authorization providers. | Optional |
 | **gatewayExternalTrafficPolicy** <br /> string | Defines the external traffic policy for the Istio Ingress Gateway Service. Valid configurations are `"Local"` or `"Cluster"`. The external traffic policy set to `"Local"` preserves the client IP in the request, but also introduces the risk of unbalanced traffic distribution.<br />WARNING: Switching **externalTrafficPolicy** may result in a temporal increase in request delay. Make sure that this is acceptable. | Enum: [Local Cluster] <br />Optional <br /> |
 | **telemetry** <br /> [Telemetry](#telemetry) | Defines the telemetry configuration of Istio. | Optional <br /> |
@@ -420,7 +420,7 @@ Appears in:
 
 ### XFCCStrategy
 
-Defines how proxy handles the x-forwarded-client-cert (XFCC) of the HTTP header.
+Defines how the proxy handles the **X-Forwarded-Client-Cert** (XFCC) of the HTTP header.
 XFCC is a proxy header that indicates certificate information of part or all of the clients or proxies that a request has passed through on its route from the client to the server.
 
 Underlying type: string


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- update Istio CR documentation with current default value from Istio upstream and specify for which proxies this setting applies to,
- specify in ADR type of proxy to which added setting apply to

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.
- [x] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [x] RBAC settings are as restrictive as possible.
- [x] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.
- [x] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
