### PR TITLE
Set GOMEMLIMIT env for manager deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,6 +61,8 @@ spec:
         env:
         - name: GODEBUG
           value: "fips140=only,tlsmlkem=0"
+        - name: GOMEMLIMIT
+          value: "400MiB"
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Set GOMEMLIMIT to prevent OOM kills by k8s
