### PR TITLE
Add xff header tests for gcp and aws using new e2e test framework.

### DIFF
--- a/.github/workflows/post-main-release-workflow.yaml
+++ b/.github/workflows/post-main-release-workflow.yaml
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test", "gcp-integration-test", "xff-header-integration-e2e-test" ]
+        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test", "gcp-integration-test", "xff-header-e2e-test" ]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test", "aws-integration-test", "xff-header-integration-e2e-test" ]
+        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test", "aws-integration-test", "xff-header-e2e-test" ]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener

--- a/.github/workflows/release-istio-2.yaml
+++ b/.github/workflows/release-istio-2.yaml
@@ -226,7 +226,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test", "gcp-integration-test", "xff-header-integration-e2e-test" ]
+        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test", "gcp-integration-test", "xff-header-e2e-test" ]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener
@@ -247,7 +247,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test", "aws-integration-test","xff-header-integration-e2e-test" ]
+        test_make_target: [ "configuration-integration-test", "mesh-communication-integration-test", "installation-integration-test", "observability-integration-test", "aws-integration-test", "xff-header-e2e-test" ]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener

--- a/Makefile
+++ b/Makefile
@@ -258,8 +258,8 @@ upgrade-test: generate-upgrade-test-manifest deploy-latest-release gotestsum
 	$(LOCALBIN)/gotestsum --format testname --rerun-fails --packages="./tests/e2e/tests/upgrade/..." --junitfile "./tests/e2e/tests/upgrade/report.xml" -- -timeout 20m
 	@echo "E2E tests completed successfully"
 
-.PHONY: xff-header-integration-e2e-test
-xff-header-integration-e2e-test: gotestsum deploy
+.PHONY: xff-header-e2e-test
+xff-header-e2e-test: gotestsum deploy
 	@echo "Running e2e tests"
 	go clean -testcache
 	$(LOCALBIN)/gotestsum --format testname --rerun-fails --packages="./tests/e2e/tests/xff_header/..." --junitfile "./tests/e2e/tests/xff_header/report.xml" -- -timeout 20m

--- a/tests/e2e/pkg/asserts/httpbin/httpbin.go
+++ b/tests/e2e/pkg/asserts/httpbin/httpbin.go
@@ -77,7 +77,7 @@ func AssertHeaders(t *testing.T, client *http.Client, url string, opts ...Assert
 			return false, err
 		}
 
-		t.Logf("Making HTTP request to endpoint: %s", url)
+		t.Logf("Making HTTP request to httpbin /headers endpoint: %s", url)
 
 		resp, err := client.Do(req)
 		if err != nil {

--- a/tests/e2e/pkg/helpers/public_ip/public_ip.go
+++ b/tests/e2e/pkg/helpers/public_ip/public_ip.go
@@ -9,7 +9,7 @@ import (
 // FetchPublicIP returns the public IP address of the caller by using the ipify API.
 func FetchPublicIP(t *testing.T) (string, error) {
 	url := "https://api.ipify.org?format=text"
-	t.Logf("Getting IP address of client from  ipify ...")
+	t.Logf("Getting IP address of client from ipify ...")
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Logf("Failed to fetch public IP of client: %v", err)

--- a/tests/e2e/tests/xff_header/xff_header_test.go
+++ b/tests/e2e/tests/xff_header/xff_header_test.go
@@ -63,7 +63,7 @@ func TestConfiguration(t *testing.T) {
 		gatewayAddress, err := load_balancer.GetLoadBalancerIP(t.Context(), c.GetControllerRuntimeClient())
 		require.NoError(t, err)
 
-		url := fmt.Sprintf("http://%s/get?show_env=true", gatewayAddress)
+		url := fmt.Sprintf("http://%s/headers", gatewayAddress)
 
 		httpbinassert.AssertHeaders(t, httpClient, url,
 			httpbinassert.WithHeaderValue("X-Forwarded-For", clientIP))


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add test for xff header for AWS and GCP using new framework for e2e tests
- adjust log info in asserter of request 
- add new test to pipelines

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.
- [x] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [x] RBAC settings are as restrictive as possible.
- [x] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [x] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.
- [x] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
