### PR TITLE
Adjust timeout fo assertion.

### DIFF
--- a/tests/e2e/tests/xff_header/xff_header_test.go
+++ b/tests/e2e/tests/xff_header/xff_header_test.go
@@ -15,6 +15,7 @@ import (
 	virtualservice "github.com/kyma-project/istio/operator/tests/e2e/pkg/helpers/virtual_service"
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 const defaultNamespace = "default"
@@ -66,7 +67,8 @@ func TestConfiguration(t *testing.T) {
 		url := fmt.Sprintf("http://%s/headers", gatewayAddress)
 
 		httpbinassert.AssertHeaders(t, httpClient, url,
-			httpbinassert.WithHeaderValue("X-Forwarded-For", clientIP))
+			httpbinassert.WithHeaderValue("X-Forwarded-For", clientIP),
+			httpbinassert.WithTimeout(90*time.Second))
 
 	})
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- adjust timeout of assertion for xff header test on aws and gcp

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.
- [x] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [x] RBAC settings are as restrictive as possible.
- [x] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [x] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.
- [x] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
