### PR TITLE
Add ADR for DNS proxying configuration support.

### DIFF
--- a/docs/contributor/adr/0013-support-for-dns-proxying-configuration.md
+++ b/docs/contributor/adr/0013-support-for-dns-proxying-configuration.md
@@ -32,10 +32,6 @@ With DNS proxying enabled:
 5. The proxy can auto-allocate non-routable virtual IPs (VIPs) to distinguish between multiple external TCP services on the same port as long as they do not use a wildcard host in the ServiceEntry.
 
 Configuration of DNS Proxying behavior by mode:
-  - Sidecar mode: Field enables or disables DNS proxying for sidecar proxy. 
-  - Ambient mode : Field doesn't affect any configuration of DNS Proxying for ztunnel proxy.
-      - Rationale: DNS proxying is always enabled in ambient mode (Istio ≥1.25)
-      - Can only be disabled per-workload via `ambient.istio.io/dns-capture=false` annotation
   - Sidecar mode: The **enableDNSProxying** field enables or disables DNS proxying for the sidecar proxy. 
   - Ambient mode: The field doesn't affect any configuration of DNS Proxying for the ztunnel proxy.
       - Rationale: DNS proxying is always enabled in ambient mode (Istio version 1.25 or later).


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- enable DNS Proxying configuration through Istio CR field `enableDNSProxying` for sidecar mode cluster-wide

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.
- [x] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [x] RBAC settings are as restrictive as possible.
- [x] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [x] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.
- [x] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #1692 
