### PR TITLE
Add note on Kubernetes version to the native sidecar doc

### DIFF
--- a/docs/user/00-20-istio-proxy-as-native-sidecar.md
+++ b/docs/user/00-20-istio-proxy-as-native-sidecar.md
@@ -18,7 +18,7 @@ Using native sidecars resolves the following problems that occur when Istio prox
 
 By default, the Istio module 1.22 and later versions use `istio-proxy` native sidecars. This setting is configured globally and applied to all Pods that allow for Istio sidecar proxy injection. However, you can override this default setting for a specific Pod, allowing it to run `istio-proxy` as a regular container instead.
 
-Furthermore, if you use the Istio module that deploys Istio version 1.27, you have the option to set the **compatibilityMode** in the Istio Custom Resource (CR) to `true`. This setting makes Istio behave as version 1.26, which uses regular `istio-proxy` containers by default.
+Furthermore, if you use the Istio module that deploys Istio version 1.27, you have the option to set the **compatibilityMode** in the Istio custom resource (CR) to `true`. This setting makes Istio behave as version 1.26, which uses regular `istio-proxy` containers by default.
 
 Istio module version | Istio version | Default `istio-proxy` Container Type
 ---------|----------|---------


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Document that Kubernetes version 1.33 or later is a prerequisite for native sidecars

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
