### PR TITLE
Update release notes for Istio 1.26.0

### DIFF
--- a/docs/release-notes/1.26.0.md
+++ b/docs/release-notes/1.26.0.md
@@ -4,13 +4,13 @@ We've updated the Istio version to 1.28.3 ([#1853](https://github.com/kyma-proje
 
 ## New Features
 - Now, you can enable the global DNS proxying setting. When enabled, DNS requests from application Pods are intercepted by Istio proxies instead of being sent directly to upstream DNS servers. See [#1692](https://github.com/kyma-project/istio/issues/1692).
-- We've added field in Istio CR that enables NetworkPolicies. For more information look into [NetworkPolicies documentation](https://kyma-project.io/external-content/istio/docs/user/technical-reference/05-20-support-for-network-policies.html).
+- We've added a new field in Istio CR that enables network policies. For more information, see [Network Policies](https://kyma-project.io/external-content/istio/docs/user/technical-reference/05-20-support-for-network-policies.html).
 
 
 ## Enhancements
 
 - We've added environment variables, which configure separate Istio FIPS images. See [#1843](https://github.com/kyma-project/istio/pull/1843).
-- [Experimental] Dual-stack support is now enabled when the `kyma-provisioning-info` ConfigMap is present and contains the **details.networkDetails.dualStackIPEnabled** field set to `true`. The field **spec.experimental.enableDualStack** is removed from the Istio CR in favor of the new approach. See: [#1871](https://github.com/kyma-project/istio/pull/1871).
+- [Experimental] Dual-stack support is now enabled when the `kyma-provisioning-info` ConfigMap is present and contains the **details.networkDetails.dualStackIPEnabled** field set to `true`. The field **spec.experimental.enableDualStack** is removed from the Istio CR in favor of the new approach. See [#1871](https://github.com/kyma-project/istio/pull/1871).
 
 ## Fixed Bugs
  - We've fixed the reconciliation failure that occurred when Istio-injected images contained SHA256 digest suffixes (e.g., image:1.28.2@sha256:abc123...). 

--- a/docs/release-notes/1.26.0.md
+++ b/docs/release-notes/1.26.0.md
@@ -4,6 +4,7 @@ We've updated the Istio version to 1.28.3 ([#1853](https://github.com/kyma-proje
 
 ## New Features
 - Now, you can enable the global DNS proxying setting. When enabled, DNS requests from application Pods are intercepted by Istio proxies instead of being sent directly to upstream DNS servers. See [#1692](https://github.com/kyma-project/istio/issues/1692).
+- We've added field in Istio CR that enables NetworkPolicies. For more information look into [NetworkPolicies documentation](https://kyma-project.io/external-content/istio/docs/user/technical-reference/05-20-support-for-network-policies.html).
 
 
 ## Enhancements


### PR DESCRIPTION
Added information about new global DNS proxying feature and NetworkPolicies support in Istio 1.26.0 release notes.

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.
- [ ] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
