### PR TITLE
Set gomemlimit based on cgroup without dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 )
 
 require (
-	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/golang/protobuf v1.5.4
 	github.com/prometheus/client_golang v1.23.2
 )
@@ -148,7 +147,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/openshift/api v0.0.0-20250806102053-6a7223edb2fc // indirect
-	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240409071808-615f978279ca // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/KimMachineGun/automemlimit v0.7.5 h1:RkbaC0MwhjL1ZuBKunGDjE/ggwAX43DwZrJqVwyveTk=
-github.com/KimMachineGun/automemlimit v0.7.5/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -329,8 +327,6 @@ github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgr
 github.com/openshift/api v0.0.0-20250806102053-6a7223edb2fc h1:kAiInOGnd0+nsDcwl5YVceHfbT8Xk7tJq1vlYDVBonA=
 github.com/openshift/api v0.0.0-20250806102053-6a7223edb2fc/go.mod h1:SPLf21TYPipzCO67BURkCfK6dcIIxx0oNRVWaOyRcXM=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
-github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/internal/memlimit/memlimit.go
+++ b/internal/memlimit/memlimit.go
@@ -1,0 +1,62 @@
+package memlimit
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	cgroupV2MemMax = "/sys/fs/cgroup/memory.max"
+	cgroupV1MemMax = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+)
+
+// SetGoMemLimitFromCgroup sets GOMEMLIMIT to pct (e.g. 0.9 for 90%) of the
+// container memory limit read from the cgroup filesystem.
+func SetGoMemLimitFromCgroup(pct float64, log logr.Logger) error {
+	if pct <= 0 || pct > 1 {
+		return fmt.Errorf("percentage must be a fraction of 1, got %f", pct)
+	}
+
+	limit, err := readCgroupLimit()
+	if err != nil {
+		return fmt.Errorf("reading cgroup memory limit: %w", err)
+	}
+
+	if limit <= 0 {
+		return fmt.Errorf("invalid memory limit: %d", limit)
+	}
+
+	target := int64(float64(limit) * pct)
+	log.Info("Setting GOMEMLIMIT", "limitMiB", bytesToMiB(limit), "targetMiB", bytesToMiB(target))
+	debug.SetMemoryLimit(target)
+	return nil
+}
+
+func readCgroupLimit() (int64, error) {
+	if b, err := os.ReadFile(cgroupV2MemMax); err == nil {
+		return parseCgroup(string(b))
+	}
+
+	b, err := os.ReadFile(cgroupV1MemMax)
+	if err != nil {
+		return 0, fmt.Errorf("unable to read cgroup memory limit: %w", err)
+	}
+	return parseCgroup(string(b))
+}
+
+func parseCgroup(raw string) (int64, error) {
+	s := strings.TrimSpace(raw)
+	if s == "max" {
+		return 0, fmt.Errorf("no memory limit set (cgroup reports 'max')")
+	}
+	return strconv.ParseInt(s, 10, 64)
+}
+
+func bytesToMiB(b int64) int64 {
+	return b / (1024 * 1024)
+}

--- a/internal/memlimit/memlimit_test.go
+++ b/internal/memlimit/memlimit_test.go
@@ -1,0 +1,56 @@
+package memlimit
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestSetGoMemLimitFromCgroup_InvalidPct(t *testing.T) {
+	tests := []struct {
+		name string
+		pct  float64
+	}{
+		{"zero", 0},
+		{"negative", -0.5},
+		{"above one", 1.1},
+	}
+	log := logr.Logger{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := SetGoMemLimitFromCgroup(tt.pct, log); err == nil {
+				t.Error("expected error for invalid percentage")
+			}
+		})
+	}
+}
+
+func TestParseCgroup_ValidValue(t *testing.T) {
+	val, err := parseCgroup("1073741824\n")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != 1073741824 {
+		t.Fatalf("expected 1073741824, got %d", val)
+	}
+}
+
+func TestParseCgroup_Max(t *testing.T) {
+	_, err := parseCgroup("max\n")
+	if err == nil {
+		t.Error("expected error for 'max' value")
+	}
+}
+
+func TestParseCgroup_InvalidValue(t *testing.T) {
+	_, err := parseCgroup("notanumber\n")
+	if err == nil {
+		t.Error("expected error for non-numeric value")
+	}
+}
+
+func TestSetMemoryLimit_Integration(t *testing.T) {
+	prev := debug.SetMemoryLimit(-1)
+	debug.SetMemoryLimit(prev)
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/istio/operator/internal/images"
+	"github.com/kyma-project/istio/operator/internal/memlimit"
 	istiocrmetrics "github.com/kyma-project/istio/operator/internal/metrics"
 
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -34,13 +35,6 @@ import (
 
 	networkingv1 "istio.io/client-go/pkg/apis/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
-	// Automemlimit is imported to automatically set the memory limit for the operator based on the available memory for the container (cgroups).
-	// This is required as with the controller running under VPA, the memory limit is not static and GOMEMLIMIT cannot be set to a fixed value.
-	// Automemlimit will set GOMEMLIMIT to 90% of the available memory for the container.
-	// TODO: This should be reevaluated after sidecar restart is fixed and memory usage is stable,
-	// as it may be possible to set a fixed GOMEMLIMIT value based on the observed memory usage.
-	_ "github.com/KimMachineGun/automemlimit"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -117,6 +111,11 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "Unable to configure Istio log scopes")
 		os.Exit(1)
+	}
+
+	// Set gomemlimit to 90% of k8s pod limits
+	if err := memlimit.SetGoMemLimitFromCgroup(0.9, setupLog); err != nil {
+		setupLog.Info("Could not set GOMEMLIMIT from cgroup", "error", err)
 	}
 
 	mgr, err := createManager(flagVar)


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Set gomemlimit automatically without dependencies

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [x] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [x] RBAC settings are as restrictive as possible.
- [x] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.
- [x] You checked if Busola updates are needed.
- [x] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
Same as in Api Gateway: https://github.com/kyma-project/api-gateway/pull/2566