### PR TITLE
Update Istio troubleshooting: Reverting the Istio Module's Deletion

### DIFF
--- a/docs/user/troubleshooting/03-50-recovering-from-unintentional-istio-removal.md
+++ b/docs/user/troubleshooting/03-50-recovering-from-unintentional-istio-removal.md
@@ -27,26 +27,6 @@ For example, the issue occurs when you delete Istio, but there are still Virtual
 
 ## Solution
 
-<!-- tabs:start -->
-#### **Kyma dashboard**
-
-1. In the **Cluster Overview** section, select **Modify Modules**.
-2. Select the Istio module.
-3. Choose **Edit**.
-4. Switch to the **YAML** section.
-5. To remove the finalizers from the Istio custom resource, delete the following lines:
-    ```bash
-    finalizers:
-    - istios.operator.kyma-project.io/istio-installation
-    ```
-    When the finalizers are removed, the Istio module is deleted. All the other resources remain in the cluster.
-6. Choose **Save**.
-7. Add the Istio module again.
-
-When you re-add the Istio module, its reconciliation is reinitiated. The Istio CR returns to the Ready state within a few seconds.
-    
-#### **kubectl**
-
 1. To edit the Istio CR, run:
     ```bash
     kubectl edit istio -n kyma-system default
@@ -60,6 +40,4 @@ When you re-add the Istio module, its reconciliation is reinitiated. The Istio C
 3. Save the changes.
 4. Add the Istio module again.
 
-When you re-add the Istio module, its reconciliation is reinitiated. The Istio CR returns to the Ready state within a few seconds.
-
-<!-- tabs:end -->
+When you re-add the Istio module, its reconciliation is reinitiated. The Istio CR returns to the `Ready` state within a few seconds.


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove Busola Instructions from the troubleshooting Reverting the Istio Module's Deletion

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.
- [ ] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
