### PR TITLE
Add "Uneven Traffic Distribution with Destination Rules" docu

### DIFF
--- a/docs/user/_sidebar.ts
+++ b/docs/user/_sidebar.ts
@@ -38,6 +38,6 @@ export default [
     { text: 'Init Containers Can\'t Access the Network', link: './troubleshooting/03-46-init-containers-cant-access-network' },
     { text: 'Modified Istio Resources', link: './troubleshooting/03-70-reconciliation-fails-on-istio-install' },
     { text: 'Istio Cannot Verify an HTTPS Certificate', link: './troubleshooting/03-90-istio-cert-unknown' },
-    { text: 'Uneven Traffic Distribution with Destination Rules', link: './troubleshooting/03-95-uneven-load-balancing-with-destination-rules' }
+    { text: 'Uneven Traffic Distribution with DestinationRules', link: './troubleshooting/03-95-uneven-load-balancing-with-destination-rules' }
     ] }
 ];

--- a/docs/user/_sidebar.ts
+++ b/docs/user/_sidebar.ts
@@ -37,6 +37,7 @@ export default [
     { text: 'Pods Created by Jobs Can\'t Finish', link: './troubleshooting/03-45-jobs-cant-finish' },
     { text: 'Init Containers Can\'t Access the Network', link: './troubleshooting/03-46-init-containers-cant-access-network' },
     { text: 'Modified Istio Resources', link: './troubleshooting/03-70-reconciliation-fails-on-istio-install' },
-    { text: 'Istio Cannot Verify an HTTPS Certificate', link: './troubleshooting/03-90-istio-cert-unknown' }
+    { text: 'Istio Cannot Verify an HTTPS Certificate', link: './troubleshooting/03-90-istio-cert-unknown' },
+    { text: 'Uneven Traffic Distribution with Destination Rules', link: './troubleshooting/03-95-uneven-load-balancing-with-destination-rules' }
     ] }
 ];

--- a/docs/user/troubleshooting/03-95-uneven-load-balancing-with-destination-rules.md
+++ b/docs/user/troubleshooting/03-95-uneven-load-balancing-with-destination-rules.md
@@ -1,26 +1,24 @@
-# Uneven Traffic Distribution with Destination Rules
+# Uneven Traffic Distribution with DestinationRules
 
 ## Symptom
 
-After applying an Istio `DestinationRule` with outlier detection, you observe uneven traffic distribution across Pods of a service.
-Some Pods receive significantly more requests than others, even though no errors or ejections are occurring.
+After applying an Istio DestinationRule with outlier detection, you observe uneven traffic distribution across the Service Pods.
+Some Pods receive significantly more requests than others, even though no errors or ejections occur.
 
 ## Cause
 
-Istio's **locality load balancing** is implicitly activated whenever `outlierDetection` is configured in a `DestinationRule`,
-even if `localityLbSetting.enabled` is not explicitly set. When active, locality load balancing routes traffic preferentially
+Istio implicitly activates locality load balancing whenever you configure **outlierDetection** in a DestinationRule,
+even if you don't explicitly set **localityLbSetting.enabled**. When active, locality load balancing routes traffic preferentially
 to endpoints in the same locality (region, zone, or sub-zone) as the source workload, using outlier detection results to
 determine endpoint health and trigger failover between localities.
-In clusters where Pods are spread across multiple zones or nodes with unequal locality label distribution, this can skew
-the load distribution, causing certain Pods to receive a disproportionate share of traffic.
+In clusters where Pods are distributed across multiple zones or nodes with unequal locality label distribution, locality-aware routing can skew load distribution. As a result, some Pods receive a disproportionate share of traffic.
 
-This behavior is not caused by circuit breaking or Pod ejection.
-Even with zero errors, the locality-aware routing algorithm can produce an uneven spread of requests across healthy Pods.
+Circuit breaking and Pod ejection do not cause this behavior.
+Even with zero errors, the locality-aware routing algorithm can produce an uneven distribution of requests across healthy Pods.
 
 ## Solution
 
-Disable locality load balancing in the `DestinationRule` by explicitly setting `loadBalancer.localityLbSetting.enabled` to `false`
-while keeping the outlier detection configuration in place.
+Disable locality load balancing in the DestinationRule by explicitly setting **loadBalancer.localityLbSetting.enabled** to `false`. Keep the outlier detection configuration in place.
 
 **Before (uneven distribution):**
 
@@ -59,7 +57,7 @@ spec:
         enabled: false
 ```
 
-Apply the updated `DestinationRule` to the cluster:
+Apply the updated DestinationRule to the cluster:
 
 ```bash
 kubectl apply -f destination-rule.yaml
@@ -70,8 +68,7 @@ After applying the change, verify that traffic is distributed evenly across all 
 
 ## Additional Information
 
-- Disabling locality load balancing does not affect the outlier detection behavior. Outlier detection will continue to monitor endpoint health and eject
-unhealthy endpoints as configured, but traffic will be distributed evenly across all healthy endpoints regardless of locality.
+- Disabling locality load balancing doesn't affect the outlier detection behavior. Outlier detection continues to monitor endpoint health and eject unhealthy endpoints as configured, but traffic is distributed evenly across all healthy endpoints regardless of locality.
 - If your deployment spans multiple zones, and you intentionally want zone-aware routing, consider fine-tuning the
   [locality weight distribution](https://istio.io/latest/docs/reference/config/networking/destination-rule/#LocalityLoadBalancerSetting-Distribute)
   instead of disabling locality load balancing entirely.

--- a/docs/user/troubleshooting/03-95-uneven-load-balancing-with-destination-rules.md
+++ b/docs/user/troubleshooting/03-95-uneven-load-balancing-with-destination-rules.md
@@ -1,0 +1,77 @@
+# Uneven Traffic Distribution with Destination Rules
+
+## Symptom
+
+After applying an Istio `DestinationRule` with outlier detection, you observe uneven traffic distribution across Pods of a service.
+Some Pods receive significantly more requests than others, even though no errors or ejections are occurring.
+
+## Cause
+
+Istio's **locality load balancing** is implicitly activated whenever `outlierDetection` is configured in a `DestinationRule`,
+even if `localityLbSetting.enabled` is not explicitly set. When active, locality load balancing routes traffic preferentially
+to endpoints in the same locality (region, zone, or sub-zone) as the source workload, using outlier detection results to
+determine endpoint health and trigger failover between localities.
+In clusters where Pods are spread across multiple zones or nodes with unequal locality label distribution, this can skew
+the load distribution, causing certain Pods to receive a disproportionate share of traffic.
+
+This behavior is not caused by circuit breaking or Pod ejection.
+Even with zero errors, the locality-aware routing algorithm can produce an uneven spread of requests across healthy Pods.
+
+## Solution
+
+Disable locality load balancing in the `DestinationRule` by explicitly setting `loadBalancer.localityLbSetting.enabled` to `false`
+while keeping the outlier detection configuration in place.
+
+**Before (uneven distribution):**
+
+```yaml
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: service-destinationrule
+spec:
+  host: service
+  trafficPolicy:
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 60s
+      maxEjectionPercent: 50
+```
+
+**After (balanced distribution):**
+
+```yaml
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: service-destinationrule
+spec:
+  host: service
+  trafficPolicy:
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 60s
+      maxEjectionPercent: 50
+    loadBalancer:
+      localityLbSetting:
+        enabled: false
+```
+
+Apply the updated `DestinationRule` to the cluster:
+
+```bash
+kubectl apply -f destination-rule.yaml
+```
+
+After applying the change, verify that traffic is distributed evenly across all Pods by checking your observability tooling
+(for example, Grafana dashboards or Prometheus metrics).
+
+## Additional Information
+
+- Disabling locality load balancing does not affect the outlier detection behavior. Outlier detection will continue to monitor endpoint health and eject
+unhealthy endpoints as configured, but traffic will be distributed evenly across all healthy endpoints regardless of locality.
+- If your deployment spans multiple zones, and you intentionally want zone-aware routing, consider fine-tuning the
+  [locality weight distribution](https://istio.io/latest/docs/reference/config/networking/destination-rule/#LocalityLoadBalancerSetting-Distribute)
+  instead of disabling locality load balancing entirely.


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add "Uneven Traffic Distribution with Destination Rules"

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.
- [ ] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
