### PR TITLE
bug: remove timestamp from description

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -3,7 +3,6 @@ package status
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -75,12 +74,6 @@ func (d Handler) UpdateToError(ctx context.Context, istioCR *operatorv1alpha2.Is
 		istioCR.Status.State = operatorv1alpha2.Error
 	}
 	istioCR.Status.Description = err.Description()
-	if len(requeueAfter) > 0 {
-		istioCR.Status.Description += fmt.Sprintf("\nWill reconcile next at %s", time.Now().
-			Add(requeueAfter[0]).Format(time.RFC1123))
-	} else {
-		istioCR.Status.Description += "\nWill not reconcile automatically"
-	}
 	return d.update(ctx, istioCR)
 }
 

--- a/tests/e2e/tests/installation/installation_test.go
+++ b/tests/e2e/tests/installation/installation_test.go
@@ -159,7 +159,6 @@ func TestInstallation(t *testing.T) {
 			),
 			istioassert.WithExpectedDescriptionContaining(
 				"Stopped Istio CR reconciliation: istio CR is not in kyma-system namespace",
-				"Will not reconcile automatically",
 			),
 		)
 	})
@@ -193,7 +192,6 @@ func TestInstallation(t *testing.T) {
 			),
 			istioassert.WithExpectedDescriptionContaining(
 				"Stopped Istio CR reconciliation: only Istio CR default in kyma-system reconciles the module",
-				"Will not reconcile automatically",
 			),
 		)
 	})

--- a/tests/integration/features/installation-suite/install.feature
+++ b/tests/integration/features/installation-suite/install.feature
@@ -66,7 +66,6 @@ Feature: Installing and uninstalling Istio module
     Then Istio CR "istio-sample" in namespace "default" has status "Error"
     And Istio CR "istio-sample" in namespace "default" has condition with reason "ReconcileFailed" of type "Ready" and status "False"
     And Istio CR "istio-sample" in namespace "default" contains description "Stopped Istio CR reconciliation: istio CR is not in kyma-system namespace"
-    And Istio CR "istio-sample" in namespace "default" contains description "Will not reconcile automatically"
 
   Scenario: Installation of Istio module with a second Istio CR in kyma-system namespace
     Given Istio CR "istio-sample" from "istio_cr_template" is applied in namespace "kyma-system"
@@ -75,7 +74,6 @@ Feature: Installing and uninstalling Istio module
     Then Istio CR "istio-sample-new" in namespace "kyma-system" has status "Warning"
     And Istio CR "istio-sample-new" in namespace "kyma-system" has condition with reason "OlderCRExists" of type "Ready" and status "False"
     And Istio CR "istio-sample-new" in namespace "kyma-system" contains description "Stopped Istio CR reconciliation: only Istio CR istio-sample in kyma-system reconciles the module"
-    And Istio CR "istio-sample-new" in namespace "kyma-system" contains description "Will not reconcile automatically"
 
   Scenario: Istio module resources are reconciled, when they are deleted manually
     Given Istio CR "istio-sample" from "istio_cr_template" is applied in namespace "kyma-system"


### PR DESCRIPTION
Storing timestamp in the description causes triggering new event in the Victoria Metrics. VMalerts registers an alert that includes the error message. Because we append timestamp in error message, this closes the old alert and fire a new one, resetting the 30-minute counter before the alert.

error message must be static, so remove the timestamp append from the message

<img width="1646" height="482" alt="image" src="https://github.com/user-attachments/assets/b5932686-5595-42e5-9342-a7a3a573a3b7" />
