### PR TITLE
Enable seccompProfile for sidecar containers

### DIFF
--- a/docs/release-notes/1.27.0.md
+++ b/docs/release-notes/1.27.0.md
@@ -39,7 +39,7 @@ Istio 1.29 enables HTTP compression (Brotli, Gzip, Zstd) for the Envoy **prometh
 - We've adapted memory limits for the Istio controller to handle increased load better and prevent out-of-memory terminations. The new limits are set to 4 Gi of memory and 4 CPU cores.
 - We've introduced a VerticalPodAutoscaler (VPA) to automatically adjust resource requests and limits based on observed usage.
 - We've added a new OTLP log attribute `network.protocol.name` to the access log provider `kyma-logs`.
-- The Istio proxy sidecar container is now configured with `seccompProfile` type `RuntimeDefault`, restricting the syscalls available to the container and reducing the attack surface.
+- The Istio proxy sidecar container is now configured with **seccompProfile** of type `RuntimeDefault`, restricting the system calls available to the container and reducing the attack surface.
 - We've adapted default tolerations of Istio CNI DaemonSet not to tolerate the `NoSchedule` taint, which is applied to nodes that are not ready.
 This change prevents the CNI DaemonSet from being scheduled on such nodes, improving the stability during node rolling updates.
 - We've added a new OTLP log attribute `network.protocol.name` to the access log provider `kyma-logs`. 

--- a/docs/release-notes/1.27.0.md
+++ b/docs/release-notes/1.27.0.md
@@ -38,6 +38,8 @@ Istio 1.29 enables HTTP compression (Brotli, Gzip, Zstd) for the Envoy **prometh
 
 - We've adapted memory limits for the Istio controller to handle increased load better and prevent out-of-memory terminations. The new limits are set to 4 Gi of memory and 4 CPU cores.
 - We've introduced a VerticalPodAutoscaler (VPA) to automatically adjust resource requests and limits based on observed usage.
+- We've added a new OTLP log attribute `network.protocol.name` to the access log provider `kyma-logs`.
+- The Istio proxy sidecar container is now configured with `seccompProfile` type `RuntimeDefault`, restricting the syscalls available to the container and reducing the attack surface.
 - We've adapted default tolerations of Istio CNI DaemonSet not to tolerate the `NoSchedule` taint, which is applied to nodes that are not ready.
 This change prevents the CNI DaemonSet from being scheduled on such nodes, improving the stability during node rolling updates.
 - We've added a new OTLP log attribute `network.protocol.name` to the access log provider `kyma-logs`. 

--- a/docs/user/00-15-overview-istio-setup.md
+++ b/docs/user/00-15-overview-istio-setup.md
@@ -12,7 +12,7 @@ See the major differences in the configuration of Istio Operator compared to ups
 - Egress traffic is not controlled. All applications deployed in the Kyma cluster can access outside resources without limitations.
 - The CNI component, used for the installation of an Istio sidecar, is provided as a DaemonSet. This means that one replica is present on every node of the target cluster.
 - The self-signed CA certificate's bit length is set to `4096` instead of the default `2048`.
-- The proxy sidecar container is configured with `seccompProfile` type `RuntimeDefault` to restrict the syscalls available to the container and reduce the attack surface.
+- The Istio proxy sidecar container is now configured with **seccompProfile** of type `RuntimeDefault`, restricting the system calls available to the container and reducing the attack surface.
 
 ## Configuration Based on the Cluster Size
 

--- a/docs/user/00-15-overview-istio-setup.md
+++ b/docs/user/00-15-overview-istio-setup.md
@@ -11,7 +11,8 @@ See the major differences in the configuration of Istio Operator compared to ups
 - [Mutual TLS (mTLS)](https://istio.io/docs/concepts/security/#mutual-tls-authentication) is enabled in the STRICT mode for workloads in the Istio service mesh.
 - Egress traffic is not controlled. All applications deployed in the Kyma cluster can access outside resources without limitations.
 - The CNI component, used for the installation of an Istio sidecar, is provided as a DaemonSet. This means that one replica is present on every node of the target cluster.
-- The self-signed CA certificate’s bit length is set to `4096` instead of the default `2048`.
+- The self-signed CA certificate's bit length is set to `4096` instead of the default `2048`.
+- The proxy sidecar container is configured with `seccompProfile` type `RuntimeDefault` to restrict the syscalls available to the container and reduce the attack surface.
 
 ## Configuration Based on the Cluster Size
 

--- a/internal/istiooperator/istio-operator-light.yaml
+++ b/internal/istiooperator/istio-operator-light.yaml
@@ -335,6 +335,8 @@ spec:
       pilotCertProvider: istiod
       priorityClassName: istio-kyma-priority
       proxy:
+        seccompProfile:
+          type: RuntimeDefault
         autoInject: enabled
         clusterDomain: cluster.local
         componentLogLevel: misc:error

--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -389,6 +389,8 @@ spec:
       pilotCertProvider: istiod
       priorityClassName: istio-kyma-priority
       proxy:
+        seccompProfile:
+          type: RuntimeDefault
         autoInject: enabled
         clusterDomain: cluster.local
         componentLogLevel: misc:error


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Enable seccompProfile for sidecar containers

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.
- [x] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [x] RBAC settings are as restrictive as possible.
- [x] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [x] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.
- [x] You checked if Busola updates are needed.
- [x] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
