### PR TITLE
chore: bump: new revision of fips images

### DIFF
--- a/config/manager/env-images.yaml
+++ b/config/manager/env-images.yaml
@@ -21,10 +21,10 @@ spec:
             - name: ztunnel
               value: europe-docker.pkg.dev/kyma-project/prod/external/istio/ztunnel:1.29.1-distroless
             - name: install-cni-fips
-              value: europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/istio-install-cni-fips:1.29.1-1
+              value: europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/istio-install-cni-fips:1.29.1-2
             - name: proxyv2-fips
-              value: europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/istio-proxy-fips:1.29.1-1
+              value: europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/istio-proxy-fips:1.29.1-2
             - name: pilot-fips
-              value: europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/istio-pilot-fips:1.29.1-1
+              value: europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/istio-pilot-fips:1.29.1-2
             - name: ztunnel-fips
-              value: europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/ztunnel-fips:1.29.1-1
+              value: europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/ztunnel-fips:1.29.1-2

--- a/fips-images.yaml
+++ b/fips-images.yaml
@@ -2,16 +2,16 @@ images:
   - source: "europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/istio-pilot-fips:1.29.1"
     target:
       name: external/istio/istio-pilot-fips
-      tag: 1.29.1-1
+      tag: 1.29.1-2
   - source: "europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/istio-install-cni-fips:1.29.1"
     target:
       name: external/istio/istio-install-cni-fips
-      tag: 1.29.1-1
+      tag: 1.29.1-2
   - source: "europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/istio-proxy-fips:1.29.1"
     target:
       name: external/istio/istio-proxy-fips
-      tag: 1.29.1-1
+      tag: 1.29.1-2
   - source: "europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/ztunnel-fips:1.29.1"
     target:
       name: external/istio/ztunnel-fips
-      tag: 1.29.1-1
+      tag: 1.29.1-2


### PR DESCRIPTION
upstream image has new revision (from Apr 11). We need a bump.
