### PR TITLE
Add conditional support for VPAs

### DIFF
--- a/api/v1alpha2/compatibility_mode.go
+++ b/api/v1alpha2/compatibility_mode.go
@@ -7,7 +7,7 @@ import (
 
 //nolint:gochecknoglobals // vairables are used to set compatibility mode for IstioOperator TODO: refactor to constants
 var (
-	PilotCompatibilityEnvVars = map[string]string{}
+	PilotCompatibilityEnvVars  = map[string]string{}
 	ProxyMetaDataCompatibility = map[string]string{}
 )
 

--- a/api/v1alpha2/istio_merge.go
+++ b/api/v1alpha2/istio_merge.go
@@ -447,6 +447,21 @@ func (i *Istio) mergeResources(op iopv1alpha1.IstioOperator, options ...MergeOpt
 	}
 
 	if i.Spec.Components == nil {
+		if opts.Features.EnableControlPlaneVPA {
+			if op.Spec.Components.Pilot != nil && op.Spec.Components.Pilot.Kubernetes != nil {
+				removeMemoryMetricsFromHPA(op.Spec.Components.Pilot.Kubernetes.HpaSpec)
+			}
+			for idx := range op.Spec.Components.IngressGateways {
+				if op.Spec.Components.IngressGateways[idx].Kubernetes != nil {
+					removeMemoryMetricsFromHPA(op.Spec.Components.IngressGateways[idx].Kubernetes.HpaSpec)
+				}
+			}
+			for idx := range op.Spec.Components.EgressGateways {
+				if op.Spec.Components.EgressGateways[idx].Kubernetes != nil {
+					removeMemoryMetricsFromHPA(op.Spec.Components.EgressGateways[idx].Kubernetes.HpaSpec)
+				}
+			}
+		}
 		return op, nil
 	}
 
@@ -643,6 +658,22 @@ func (i *Istio) mergeResources(op iopv1alpha1.IstioOperator, options ...MergeOpt
 		}
 	}
 
+	if opts.Features.EnableControlPlaneVPA {
+		if op.Spec.Components.Pilot != nil && op.Spec.Components.Pilot.Kubernetes != nil {
+			removeMemoryMetricsFromHPA(op.Spec.Components.Pilot.Kubernetes.HpaSpec)
+		}
+		for idx := range op.Spec.Components.IngressGateways {
+			if op.Spec.Components.IngressGateways[idx].Kubernetes != nil {
+				removeMemoryMetricsFromHPA(op.Spec.Components.IngressGateways[idx].Kubernetes.HpaSpec)
+			}
+		}
+		for idx := range op.Spec.Components.EgressGateways {
+			if op.Spec.Components.EgressGateways[idx].Kubernetes != nil {
+				removeMemoryMetricsFromHPA(op.Spec.Components.EgressGateways[idx].Kubernetes.HpaSpec)
+			}
+		}
+	}
+
 	return op, nil
 }
 
@@ -751,4 +782,20 @@ func mergeK8sConfig(base *iopv1alpha1.KubernetesResources, newConfig KubernetesR
 		}
 	}
 	return nil
+}
+
+func removeMemoryMetricsFromHPA(hpaSpec *autoscalingv2.HorizontalPodAutoscalerSpec) {
+	if hpaSpec == nil || len(hpaSpec.Metrics) == 0 {
+		return
+	}
+	filtered := make([]autoscalingv2.MetricSpec, 0, len(hpaSpec.Metrics))
+	for _, metric := range hpaSpec.Metrics {
+		if metric.Type == autoscalingv2.ResourceMetricSourceType &&
+			metric.Resource != nil &&
+			metric.Resource.Name == corev1.ResourceMemory {
+			continue
+		}
+		filtered = append(filtered, metric)
+	}
+	hpaSpec.Metrics = filtered
 }

--- a/api/v1alpha2/merge_test.go
+++ b/api/v1alpha2/merge_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	istiov1alpha2 "github.com/kyma-project/istio/operator/api/v1alpha2"
+	istiofeatures "github.com/kyma-project/istio/operator/internal/istiofeatures"
 
 	"github.com/onsi/ginkgo/v2/types"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -15,6 +16,7 @@ import (
 	"istio.io/istio/operator/pkg/values"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/util/protomarshal"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -1260,6 +1262,111 @@ var _ = Describe("Merge", func() {
 
 			replicas = *out.Spec.Components.IngressGateways[0].Kubernetes.HpaSpec.MinReplicas
 			Expect(replicas).To(Equal(minReplicas))
+		})
+	})
+
+	Context("control plane VPA and HPA interaction", func() {
+		It("should remove memory metrics from HPA when enableControlPlaneVPA is true", func() {
+			// given
+			iop := iopv1alpha1.IstioOperator{
+				Spec: iopv1alpha1.IstioOperatorSpec{
+					Components: &iopv1alpha1.IstioComponentSpec{
+						Pilot: &iopv1alpha1.ComponentSpec{
+							Kubernetes: &iopv1alpha1.KubernetesResources{
+								HpaSpec: &autoscalingv2.HorizontalPodAutoscalerSpec{
+									Metrics: []autoscalingv2.MetricSpec{
+										{
+											Type: autoscalingv2.ResourceMetricSourceType,
+											Resource: &autoscalingv2.ResourceMetricSource{
+												Name: corev1.ResourceCPU,
+												Target: autoscalingv2.MetricTarget{
+													Type:               autoscalingv2.UtilizationMetricType,
+													AverageUtilization: ptr.To(int32(80)),
+												},
+											},
+										},
+										{
+											Type: autoscalingv2.ResourceMetricSourceType,
+											Resource: &autoscalingv2.ResourceMetricSource{
+												Name: corev1.ResourceMemory,
+												Target: autoscalingv2.MetricTarget{
+													Type:               autoscalingv2.UtilizationMetricType,
+													AverageUtilization: ptr.To(int32(70)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			istioCR := istiov1alpha2.Istio{
+				Spec: istiov1alpha2.IstioSpec{},
+			}
+
+			features := istiofeatures.IstioFeatures{EnableControlPlaneVPA: true}
+
+			// when
+			result, err := istioCR.MergeInto(iop, istiov1alpha2.WithFeatures(features))
+
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(result.Spec.Components.Pilot.Kubernetes.HpaSpec.Metrics).To(HaveLen(1))
+			Expect(result.Spec.Components.Pilot.Kubernetes.HpaSpec.Metrics[0].Resource.Name).To(Equal(corev1.ResourceCPU))
+		})
+
+		It("should keep memory metrics in HPA when enableControlPlaneVPA is false", func() {
+			// given
+			iop := iopv1alpha1.IstioOperator{
+				Spec: iopv1alpha1.IstioOperatorSpec{
+					Components: &iopv1alpha1.IstioComponentSpec{
+						Pilot: &iopv1alpha1.ComponentSpec{
+							Kubernetes: &iopv1alpha1.KubernetesResources{
+								HpaSpec: &autoscalingv2.HorizontalPodAutoscalerSpec{
+									Metrics: []autoscalingv2.MetricSpec{
+										{
+											Type: autoscalingv2.ResourceMetricSourceType,
+											Resource: &autoscalingv2.ResourceMetricSource{
+												Name: corev1.ResourceCPU,
+												Target: autoscalingv2.MetricTarget{
+													Type:               autoscalingv2.UtilizationMetricType,
+													AverageUtilization: ptr.To(int32(80)),
+												},
+											},
+										},
+										{
+											Type: autoscalingv2.ResourceMetricSourceType,
+											Resource: &autoscalingv2.ResourceMetricSource{
+												Name: corev1.ResourceMemory,
+												Target: autoscalingv2.MetricTarget{
+													Type:               autoscalingv2.UtilizationMetricType,
+													AverageUtilization: ptr.To(int32(70)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			istioCR := istiov1alpha2.Istio{
+				Spec: istiov1alpha2.IstioSpec{},
+			}
+
+			features := istiofeatures.IstioFeatures{EnableControlPlaneVPA: false}
+
+			// when
+			result, err := istioCR.MergeInto(iop, istiov1alpha2.WithFeatures(features))
+
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(result.Spec.Components.Pilot.Kubernetes.HpaSpec.Metrics).To(HaveLen(2))
 		})
 	})
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: europe-docker.pkg.dev/kyma-project/prod/istio-manager
-  newTag: 1.0.0
+  newName: i566483/istio
+  newTag: vpa-cp-3
 patches:
 - path: env-images.yaml

--- a/docs/contributor/adr/0017-vpa-control-plane.md
+++ b/docs/contributor/adr/0017-vpa-control-plane.md
@@ -1,0 +1,85 @@
+# VPA for Istio Control Plane Components
+
+## Status
+Proposed
+
+## Context
+This ADR addresses [kyma-project/istio#2011](https://github.com/kyma-project/istio/issues/2011).
+The goal is to conditionally enable Vertical Pod Autoscaler (VPA) for Istio control plane components to support mesh scaling on large clusters. The VPA must coexist with the existing HPA without conflicts — HPA handles CPU-based horizontal scaling, while VPA optimizes memory resource allocation.
+
+## Decision
+
+### Feature Flag
+
+A new boolean field `enableControlPlaneVPA` is added to the `IstioFeatures` struct in `internal/istiofeatures/features.go`:
+
+```go
+type IstioFeatures struct {
+    DisableCni            bool `json:"disableCni"`
+    EnableControlPlaneVPA bool `json:"enableControlPlaneVPA"`
+}
+```
+
+Users enable it by setting the flag in the `istio-features` ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-features
+  namespace: kyma-system
+data:
+  features: |
+    {
+      "enableControlPlaneVPA": true
+    }
+```
+
+### VPA Resources
+
+When enabled, the operator creates VPA resources in `istio-system` for:
+
+| Target               | Kind       | Container   | minAllowed memory | maxAllowed memory |
+|----------------------|------------|-------------|-------------------|-------------------|
+| istiod               | Deployment | discovery   | 512Mi             | 16Gi              |
+| istio-ingressgateway | Deployment | istio-proxy | 128Mi             | 16Gi              |
+| istio-egressgateway  | Deployment | istio-proxy | 128Mi             | 16Gi              |
+| istio-cni-node       | DaemonSet  | install-cni | 512Mi             | 16Gi              |
+
+All VPAs share these settings:
+- `controlledResources: [memory]`
+- `controlledValues: RequestsAndLimits`
+- `updatePolicy.updateMode: InPlaceOrRecreate`
+- `updatePolicy.minReplicas: 1`
+
+### HPA Memory Metric Prevention
+
+When `enableControlPlaneVPA` is true, the operator must ensure that no memory-based metric is present in the HPA for pilot or gateways. The upstream Istio chart template (`autoscale.yaml`) conditionally adds a memory metric if `values.pilot.memory.targetAverageUtilization` is set:
+
+```yaml
+{{- if .Values.memory.targetAverageUtilization }}
+- type: Resource
+  resource:
+    name: memory
+    ...
+{{- end }}
+```
+
+To be defensive against future changes, during the IstioOperator merge step (`mergeResources` in `api/v1alpha2/istio_merge.go`), when `Features.EnableControlPlaneVPA` is true:
+
+1. Remove any `memory` metric from `hpaSpec.metrics` for pilot, ingress gateway, and egress gateway components if present.
+2. Ensure `values.pilot.memory` is not set (or explicitly set to empty) in the rendered IstioOperator values.
+
+This guarantees HPA only scales on CPU while VPA manages memory.
+
+### Backward Compatibility
+
+- Clusters without VPA CRD: no VPA resources created (same guard as operator VPA).
+- ConfigMap absent or feature not set: defaults to `false`, no VPAs created.
+- Egress gateway disabled: In case egress-gateway is not deployed in the cluster VPA controller will ignore the VPA without an error.
+
+## Consequences
+
+- Clusters with VPA support and the feature enabled will have memory-optimized Istio control plane components without manual tuning.
+- HPA continues to scale horizontally based on CPU; VPA adjusts memory vertically. No conflict between the two autoscalers.
+- The feature is opt-in and alpha — users must explicitly enable it via ConfigMap.

--- a/docs/contributor/adr/0017-vpa-control-plane.md
+++ b/docs/contributor/adr/0017-vpa-control-plane.md
@@ -5,13 +5,13 @@ Proposed
 
 ## Context
 This ADR addresses [kyma-project/istio#2011](https://github.com/kyma-project/istio/issues/2011).
-The goal is to conditionally enable Vertical Pod Autoscaler (VPA) for Istio control plane components to support mesh scaling on large clusters. The VPA must coexist with the existing HPA without conflicts — HPA handles CPU-based horizontal scaling, while VPA optimizes memory resource allocation.
+The goal is to conditionally enable VerticalPodAutoscaler (VPA) for Istio control plane components to support mesh scaling on large clusters. The VPA must coexist with the existing HPA without conflicts — HPA handles CPU-based horizontal scaling, while VPA optimizes memory resource allocation.
 
 ## Decision
 
 ### Feature Flag
 
-A new boolean field `enableControlPlaneVPA` is added to the `IstioFeatures` struct in `internal/istiofeatures/features.go`:
+A new boolean field **enableControlPlaneVPA** is added to the **IstioFeatures** struct in `internal/istiofeatures/features.go`:
 
 ```go
 type IstioFeatures struct {
@@ -37,14 +37,14 @@ data:
 
 ### VPA Resources
 
-When enabled, the operator creates VPA resources in `istio-system` for:
+When enabled, the operator creates VPA resources in `istio-system` for the following components:
 
 | Target               | Kind       | Container   | minAllowed memory | maxAllowed memory |
 |----------------------|------------|-------------|-------------------|-------------------|
-| istiod               | Deployment | discovery   | 512Mi             | 16Gi              |
-| istio-ingressgateway | Deployment | istio-proxy | 128Mi             | 16Gi              |
-| istio-egressgateway  | Deployment | istio-proxy | 128Mi             | 16Gi              |
-| istio-cni-node       | DaemonSet  | install-cni | 512Mi             | 16Gi              |
+| istiod               | Deployment | discovery   | 512 Mi             | 16 Gi              |
+| istio-ingressgateway | Deployment | istio-proxy | 128 Mi             | 16 Gi              |
+| istio-egressgateway  | Deployment | istio-proxy | 128 Mi             | 16 Gi              |
+| istio-cni-node       | DaemonSet  | install-cni | 512 Mi             | 16 Gi              |
 
 All VPAs share these settings:
 - `controlledResources: [memory]`
@@ -54,7 +54,7 @@ All VPAs share these settings:
 
 ### HPA Memory Metric Prevention
 
-When `enableControlPlaneVPA` is true, the operator must ensure that no memory-based metric is present in the HPA for pilot or gateways. The upstream Istio chart template (`autoscale.yaml`) conditionally adds a memory metric if `values.pilot.memory.targetAverageUtilization` is set:
+When **enableControlPlaneVPA** is true, the operator must ensure that no memory-based metric is present in the HPA for pilot or gateways. The upstream Istio chart template (`autoscale.yaml`) conditionally adds a memory metric if **values.pilot.memory.targetAverageUtilization** is set:
 
 ```yaml
 {{- if .Values.memory.targetAverageUtilization }}
@@ -65,10 +65,10 @@ When `enableControlPlaneVPA` is true, the operator must ensure that no memory-ba
 {{- end }}
 ```
 
-To be defensive against future changes, during the IstioOperator merge step (`mergeResources` in `api/v1alpha2/istio_merge.go`), when `Features.EnableControlPlaneVPA` is true:
+To be defensive against future changes, during the Istio Operator merge step (`mergeResources` in `api/v1alpha2/istio_merge.go`), when **Features.EnableControlPlaneVPA** is true:
 
-1. Remove any `memory` metric from `hpaSpec.metrics` for pilot, ingress gateway, and egress gateway components if present.
-2. Ensure `values.pilot.memory` is not set (or explicitly set to empty) in the rendered IstioOperator values.
+1. Remove any `memory` metric from **hpaSpec.metrics** for pilot, ingress gateway, and egress gateway components if present.
+2. Ensure **values.pilot.memory** is not set (or explicitly set to empty) in the rendered Istio Operator values.
 
 This guarantees HPA only scales on CPU while VPA manages memory.
 

--- a/docs/release-notes/1.28.0.md
+++ b/docs/release-notes/1.28.0.md
@@ -1,0 +1,4 @@
+## New Experimental Features
+
+- We've added support for Vertical Pod Autoscaler (VPA) for Istio control plane components (istiod, ingress gateway, egress gateway, CNI).
+See [Alpha Istio Features](../user/00-45-istio-features-configmap.md). See [#2011](https://github.com/kyma-project/istio/issues/2011).

--- a/docs/user/00-45-istio-features-configmap.md
+++ b/docs/user/00-45-istio-features-configmap.md
@@ -63,9 +63,30 @@ This introduces the following risks:
 - **Bypass risk** – Any container in the Pod that runs before `istio-init` completes, or any container that also holds `NET_ADMIN`/`NET_RAW` capabilities, could potentially modify or bypass the `iptables` rules that enforce traffic interception. With Istio CNI, this concern is eliminated because interception is set up by a privileged node-level agent before the Pod's containers start.
 - **Increased attack surface on nodes** – While the `istio-init` container only affects its own network namespace, having `NET_ADMIN`-capable init containers increases the overall attack surface compared to the CNI-based approach, where privilege escalation is confined to the dedicated CNI DaemonSet.
 
+### **enableControlPlaneVPA**
+
+**Type:** `boolean`
+**Default:** `false`
+
+When set to `true`, the Istio module creates [Vertical Pod Autoscaler (VPA)](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) resources for Istio control plane components: istiod, ingress gateway, egress gateway, and CNI DaemonSet.
+
+The VPA manages **memory** resources only, allowing it to coexist safely with the existing Horizontal Pod Autoscaler (HPA) that scales based on CPU utilization. This enables automatic memory optimization for large-scale mesh deployments.
+
+#### Prerequisites
+
+- The cluster must have the VPA Custom Resource Definition (`verticalpodautoscalers.autoscaling.k8s.io`) installed. If the CRD is not present, the VPA resources are silently skipped.
+
+#### Behavior
+
+When enabled:
+- VPA resources are created in the `istio-system` namespace targeting istiod, istio-ingressgateway, istio-egressgateway, and istio-cni-node
+- Each VPA uses `updateMode: InPlaceOrRecreate` for non-disruptive scaling where supported
+- Only memory requests and limits are managed (`controlledResources: [memory]`)
+- Any memory-based metrics in the HPA are automatically removed to prevent autoscaler conflicts
 
 ## Feature Flags
 
 | Flag         | Type      | Default | Description                                                                                                                                                                                     |
 |--------------|-----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **disableCni** | `boolean` | `false` | When `true`, disables the Istio CNI node agent and falls back to the `istio-init` init container approach. See [Security Risks of Disabling Istio CNI](#security-risks-of-disabling-istio-cni). |
+| **enableControlPlaneVPA** | `boolean` | `false` | When `true`, creates VPA resources for Istio control plane components (istiod, gateways, CNI) managing memory only. Requires VPA CRD in the cluster. See [enableControlPlaneVPA](#enablecontrolplanevpa). |

--- a/docs/user/00-45-istio-features-configmap.md
+++ b/docs/user/00-45-istio-features-configmap.md
@@ -68,9 +68,9 @@ This introduces the following risks:
 **Type:** `boolean`
 **Default:** `false`
 
-When set to `true`, the Istio module creates [Vertical Pod Autoscaler (VPA)](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) resources for Istio control plane components: istiod, ingress gateway, egress gateway, and CNI DaemonSet.
+When set to `true`, the Istio module creates [VerticalPodAutoscaler (VPA)](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) resources for Istio control plane components: istiod, ingress gateway, egress gateway, and CNI DaemonSet.
 
-The VPA manages **memory** resources only, allowing it to coexist safely with the existing Horizontal Pod Autoscaler (HPA) that scales based on CPU utilization. This enables automatic memory optimization for large-scale mesh deployments.
+The VPA manages **memory** resources only, allowing it to coexist safely with the existing HorizontalPodAutoscaler (HPA) that scales based on CPU utilization. This enables automatic memory optimization for large-scale mesh deployments.
 
 #### Prerequisites
 
@@ -79,10 +79,10 @@ The VPA manages **memory** resources only, allowing it to coexist safely with th
 #### Behavior
 
 When enabled:
-- VPA resources are created in the `istio-system` namespace targeting istiod, istio-ingressgateway, istio-egressgateway, and istio-cni-node
-- Each VPA uses `updateMode: InPlaceOrRecreate` for non-disruptive scaling where supported
-- Only memory requests and limits are managed (`controlledResources: [memory]`)
-- Any memory-based metrics in the HPA are automatically removed to prevent autoscaler conflicts
+- VPA resources are created in the `istio-system` namespace targeting istiod, istio-ingressgateway, istio-egressgateway, and istio-cni-node.
+- Each VPA uses `updateMode: InPlaceOrRecreate` for non-disruptive scaling where supported.
+- Only memory requests and limits are managed (`controlledResources: [memory]`).
+- Any memory-based metrics in the HPA are automatically removed to prevent autoscaler conflicts.
 
 ## Feature Flags
 

--- a/internal/istiofeatures/features.go
+++ b/internal/istiofeatures/features.go
@@ -17,7 +17,8 @@ const (
 )
 
 type IstioFeatures struct {
-	DisableCni bool `json:"disableCni"`
+	DisableCni            bool `json:"disableCni"`
+	EnableControlPlaneVPA bool `json:"enableControlPlaneVPA"`
 }
 
 func Get(ctx context.Context, k8sClient client.Client) (IstioFeatures, error) {

--- a/internal/istiofeatures/features_test.go
+++ b/internal/istiofeatures/features_test.go
@@ -74,6 +74,24 @@ func TestGetIstioFeatures_ConfigMapExists(t *testing.T) {
 			want:    istiofeatures.IstioFeatures{},
 			wantErr: true,
 		},
+		{
+			name:    "enableControlPlaneVPA set to true",
+			cmData:  map[string]string{"features": `{"enableControlPlaneVPA": true}`},
+			want:    istiofeatures.IstioFeatures{EnableControlPlaneVPA: true},
+			wantErr: false,
+		},
+		{
+			name:    "enableControlPlaneVPA set to false",
+			cmData:  map[string]string{"features": `{"enableControlPlaneVPA": false}`},
+			want:    istiofeatures.IstioFeatures{EnableControlPlaneVPA: false},
+			wantErr: false,
+		},
+		{
+			name:    "both features set",
+			cmData:  map[string]string{"features": `{"disableCni": true, "enableControlPlaneVPA": true}`},
+			want:    istiofeatures.IstioFeatures{DisableCni: true, EnableControlPlaneVPA: true},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/reconciliations/istioresources/control_plane_vpa.go
+++ b/internal/reconciliations/istioresources/control_plane_vpa.go
@@ -1,0 +1,88 @@
+package istioresources
+
+import (
+	"context"
+	_ "embed"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/kyma-project/istio/operator/internal/resources"
+)
+
+//go:embed control_plane_vpas/istiod.yaml
+var controlPlaneVPAIstiod []byte
+
+//go:embed control_plane_vpas/ingress-gateway.yaml
+var controlPlaneVPAIngressGateway []byte
+
+//go:embed control_plane_vpas/egress-gateway.yaml
+var controlPlaneVPAEgressGateway []byte
+
+//go:embed control_plane_vpas/cni.yaml
+var controlPlaneVPACni []byte
+
+type ControlPlaneVPA struct {
+	shouldDelete bool
+}
+
+func NewControlPlaneVPA(shouldDelete bool) ControlPlaneVPA {
+	return ControlPlaneVPA{shouldDelete: shouldDelete}
+}
+
+func (v ControlPlaneVPA) reconcile(ctx context.Context, k8sClient client.Client, owner metav1.OwnerReference, _ map[string]string) (controllerutil.OperationResult, error) {
+	vpaAvailable, err := isVPACRDPresent(ctx, k8sClient)
+	if err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+
+	if !vpaAvailable {
+		return controllerutil.OperationResultNone, nil
+	}
+
+	manifests := [][]byte{
+		controlPlaneVPAIstiod,
+		controlPlaneVPAIngressGateway,
+		controlPlaneVPAEgressGateway,
+		controlPlaneVPACni,
+	}
+
+	if v.shouldDelete {
+		return deleteAll(ctx, k8sClient, manifests)
+	}
+
+	return applyAll(ctx, k8sClient, manifests, nil)
+}
+
+func (ControlPlaneVPA) Name() string {
+	return "VerticalPodAutoscaler/control-plane"
+}
+
+func applyAll(ctx context.Context, k8sClient client.Client, manifests [][]byte, owner *metav1.OwnerReference) (controllerutil.OperationResult, error) {
+	combinedResult := controllerutil.OperationResultNone
+	for _, manifest := range manifests {
+		result, err := resources.Apply(ctx, k8sClient, manifest, owner)
+		if err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		if result != controllerutil.OperationResultNone {
+			combinedResult = result
+		}
+	}
+	return combinedResult, nil
+}
+
+func deleteAll(ctx context.Context, k8sClient client.Client, manifests [][]byte) (controllerutil.OperationResult, error) {
+	combinedResult := controllerutil.OperationResultNone
+	for _, manifest := range manifests {
+		result, err := resources.DeleteIfPresent(ctx, k8sClient, manifest)
+		if err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		if result != controllerutil.OperationResultNone {
+			combinedResult = result
+		}
+	}
+	return combinedResult, nil
+}

--- a/internal/reconciliations/istioresources/control_plane_vpa_test.go
+++ b/internal/reconciliations/istioresources/control_plane_vpa_test.go
@@ -1,0 +1,133 @@
+package istioresources
+
+import (
+	"context"
+
+	"github.com/kyma-project/istio/operator/internal/resources"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ = Describe("ControlPlaneVPA", func() {
+	templateValues := map[string]string{}
+	owner := metav1.OwnerReference{
+		APIVersion: "operator.kyma-project.io/v1alpha2",
+		Kind:       "Istio",
+		Name:       "owner-name",
+		UID:        "owner-uid",
+	}
+
+	Context("when VPA CRD is present", func() {
+		It("should create all control plane VPAs", func() {
+			// given
+			k8sClient := createFakeClient(createVPACRD())
+			sample := NewControlPlaneVPA(false)
+
+			// when
+			changed, err := sample.reconcile(context.Background(), k8sClient, owner, templateValues)
+
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(changed).To(Equal(controllerutil.OperationResultCreated))
+
+			vpaList := unstructured.UnstructuredList{}
+			vpaList.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "autoscaling.k8s.io",
+				Version: "v1",
+				Kind:    "VerticalPodAutoscalerList",
+			})
+			listErr := k8sClient.List(context.Background(), &vpaList)
+			Expect(listErr).To(Not(HaveOccurred()))
+			Expect(vpaList.Items).To(HaveLen(4))
+
+			expectedNames := []string{"istiod-vpa", "istio-ingressgateway-vpa", "istio-egressgateway-vpa", "istio-cni-node-vpa"}
+			for _, vpa := range vpaList.Items {
+				Expect(expectedNames).To(ContainElement(vpa.GetName()))
+				Expect(vpa.GetNamespace()).To(Equal("istio-system"))
+				Expect(vpa.GetAnnotations()).To(Not(BeNil()))
+				Expect(vpa.GetAnnotations()[resources.DisclaimerKey]).To(Not(BeEmpty()))
+				Expect(vpa.GetLabels()).ToNot(BeNil())
+				Expect(vpa.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/version", "dev"))
+				Expect(vpa.GetOwnerReferences()).To(BeEmpty())
+			}
+		})
+
+		It("should return none if no change was applied on second reconciliation", func() {
+			// given
+			k8sClient := createFakeClient(createVPACRD())
+			sample := NewControlPlaneVPA(false)
+
+			// first reconciliation
+			changed, err := sample.reconcile(context.Background(), k8sClient, owner, templateValues)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(changed).To(Equal(controllerutil.OperationResultCreated))
+
+			// when - second reconciliation
+			sample = NewControlPlaneVPA(false)
+			changed, err = sample.reconcile(context.Background(), k8sClient, owner, templateValues)
+
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(changed).To(Equal(controllerutil.OperationResultNone))
+		})
+
+		It("should delete all control plane VPAs when shouldDelete is true", func() {
+			// given
+			k8sClient := createFakeClient(createVPACRD())
+			createSample := NewControlPlaneVPA(false)
+			_, err := createSample.reconcile(context.Background(), k8sClient, owner, templateValues)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// when
+			deleteSample := NewControlPlaneVPA(true)
+			changed, err := deleteSample.reconcile(context.Background(), k8sClient, owner, templateValues)
+
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(changed).To(Equal(controllerutil.OperationResultUpdated))
+
+			vpaList := unstructured.UnstructuredList{}
+			vpaList.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "autoscaling.k8s.io",
+				Version: "v1",
+				Kind:    "VerticalPodAutoscalerList",
+			})
+			listErr := k8sClient.List(context.Background(), &vpaList)
+			Expect(listErr).To(Not(HaveOccurred()))
+			Expect(vpaList.Items).To(BeEmpty())
+		})
+	})
+
+	Context("when VPA CRD is not present", func() {
+		It("should not create any control plane VPAs", func() {
+			// given
+			k8sClient := createFakeClient()
+			sample := NewControlPlaneVPA(false)
+
+			// when
+			changed, err := sample.reconcile(context.Background(), k8sClient, owner, templateValues)
+
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(changed).To(Equal(controllerutil.OperationResultNone))
+		})
+
+		It("should not attempt delete when VPA CRD is not present", func() {
+			// given
+			k8sClient := createFakeClient()
+			sample := NewControlPlaneVPA(true)
+
+			// when
+			changed, err := sample.reconcile(context.Background(), k8sClient, owner, templateValues)
+
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(changed).To(Equal(controllerutil.OperationResultNone))
+		})
+	})
+})

--- a/internal/reconciliations/istioresources/control_plane_vpas/cni.yaml
+++ b/internal/reconciliations/istioresources/control_plane_vpas/cni.yaml
@@ -1,0 +1,29 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: istio-cni-node-vpa
+  namespace: istio-system
+  labels:
+    kyma-project.io/module: istio
+    app.kubernetes.io/component: cni
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/name: istio-cni-node
+    app.kubernetes.io/instance: istio-cni-node-default
+spec:
+  resourcePolicy:
+    containerPolicies:
+      - containerName: install-cni
+        controlledResources:
+          - memory
+        controlledValues: RequestsAndLimits
+        maxAllowed:
+          memory: 16Gi
+        minAllowed:
+          memory: 512Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: istio-cni-node
+  updatePolicy:
+    minReplicas: 1
+    updateMode: InPlaceOrRecreate

--- a/internal/reconciliations/istioresources/control_plane_vpas/egress-gateway.yaml
+++ b/internal/reconciliations/istioresources/control_plane_vpas/egress-gateway.yaml
@@ -1,0 +1,29 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: istio-egressgateway-vpa
+  namespace: istio-system
+  labels:
+    kyma-project.io/module: istio
+    app.kubernetes.io/component: egressgateway
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/name: istio-egressgateway
+    app.kubernetes.io/instance: istio-egressgateway-default
+spec:
+  resourcePolicy:
+    containerPolicies:
+      - containerName: istio-proxy
+        controlledResources:
+          - memory
+        controlledValues: RequestsAndLimits
+        maxAllowed:
+          memory: 16Gi
+        minAllowed:
+          memory: 128Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istio-egressgateway
+  updatePolicy:
+    minReplicas: 1
+    updateMode: InPlaceOrRecreate

--- a/internal/reconciliations/istioresources/control_plane_vpas/ingress-gateway.yaml
+++ b/internal/reconciliations/istioresources/control_plane_vpas/ingress-gateway.yaml
@@ -1,0 +1,29 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: istio-ingressgateway-vpa
+  namespace: istio-system
+  labels:
+    kyma-project.io/module: istio
+    app.kubernetes.io/component: ingressgateway
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/name: istio-ingressgateway
+    app.kubernetes.io/instance: istio-ingressgateway-default
+spec:
+  resourcePolicy:
+    containerPolicies:
+      - containerName: istio-proxy
+        controlledResources:
+          - memory
+        controlledValues: RequestsAndLimits
+        maxAllowed:
+          memory: 16Gi
+        minAllowed:
+          memory: 128Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istio-ingressgateway
+  updatePolicy:
+    minReplicas: 1
+    updateMode: InPlaceOrRecreate

--- a/internal/reconciliations/istioresources/control_plane_vpas/istiod.yaml
+++ b/internal/reconciliations/istioresources/control_plane_vpas/istiod.yaml
@@ -1,0 +1,29 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: istiod-vpa
+  namespace: istio-system
+  labels:
+    kyma-project.io/module: istio
+    app.kubernetes.io/component: pilot
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/name: istiod
+    app.kubernetes.io/instance: istiod-default
+spec:
+  resourcePolicy:
+    containerPolicies:
+      - containerName: discovery
+        controlledResources:
+          - memory
+        controlledValues: RequestsAndLimits
+        maxAllowed:
+          memory: 16Gi
+        minAllowed:
+          memory: 512Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istiod
+  updatePolicy:
+    minReplicas: 1
+    updateMode: InPlaceOrRecreate

--- a/internal/reconciliations/istioresources/reconciliation.go
+++ b/internal/reconciliations/istioresources/reconciliation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kyma-project/istio/operator/internal/clusterconfig"
 	"github.com/kyma-project/istio/operator/internal/describederrors"
+	"github.com/kyma-project/istio/operator/internal/istiofeatures"
 )
 
 type ResourcesReconciliation interface {
@@ -43,7 +44,12 @@ func (r *ResourcesReconciler) Reconcile(ctx context.Context, istioCR v1alpha2.Is
 		return describederrors.NewDescribedError(err, "could not determine cluster provider")
 	}
 
-	resources, err := getResources(r.client, provider, istioCR)
+	features, featErr := istiofeatures.Get(ctx, r.client)
+	if featErr != nil {
+		ctrl.Log.V(1).Info("Could not get Istio features for resource reconciliation, proceeding with defaults", "error", featErr)
+	}
+
+	resources, err := getResources(r.client, provider, istioCR, features)
 	if err != nil {
 		ctrl.Log.Error(err, "Failed to initialise Istio resources")
 		return describederrors.NewDescribedError(err, "Istio controller failed to initialise Istio resources")
@@ -72,7 +78,7 @@ func (r *ResourcesReconciler) Reconcile(ctx context.Context, istioCR v1alpha2.Is
 }
 
 // getResources returns all Istio resources required for the reconciliation specific for the given hyperscaler.
-func getResources(k8sClient client.Client, provider string, istioCR v1alpha2.Istio) ([]Resource, error) {
+func getResources(k8sClient client.Client, provider string, istioCR v1alpha2.Istio, features istiofeatures.IstioFeatures) ([]Resource, error) {
 	// @Ressetkk: this logic needs to be moved to main reconciliation loop.
 	// Remove dynamic assignment of resource reconcilers.
 	// Can't write proper tests if I don't know which resources are reconciled in the loop.
@@ -82,6 +88,7 @@ func getResources(k8sClient client.Client, provider string, istioCR v1alpha2.Ist
 		toDeleteResources := []Resource{
 			NewNetworkPolicies(true),
 			NewVPA(true),
+			NewControlPlaneVPA(true),
 		}
 		return toDeleteResources, nil
 	}
@@ -89,6 +96,7 @@ func getResources(k8sClient client.Client, provider string, istioCR v1alpha2.Ist
 		NewPeerAuthenticationMtls(false),
 		NewNetworkPolicies(!istioCR.Spec.NetworkPoliciesEnabled),
 		NewVPA(false),
+		NewControlPlaneVPA(!features.EnableControlPlaneVPA),
 	}
 
 	switch provider {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `enableControlPlaneVPA` feature flag to the `istio-features` ConfigMap. When set to `true`, the Istio module creates VPA resources for Istio control plane components (istiod, ingress gateway, egress gateway, CNI DaemonSet) in the `istio-system` namespace.

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.
- [x] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [x] RBAC settings are as restrictive as possible.
- [x] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.
- [x] You checked if Busola updates are needed.
- [x] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**

- #2011
