### PR TITLE
Fixing the upgrade test in PR flow

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -136,7 +136,7 @@ jobs:
       - uses: ./.github/actions/e2e-test-k3d
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_BRANCH: ${{ github.ref_name }}
+          TARGET_BRANCH: ${{ github.base_ref }}
         with:
           test_make_target: "istio-upgrade-integration-test"
           operator-version: ${{ needs.get-image.outputs.operator_version }}
@@ -246,7 +246,7 @@ jobs:
       - uses: ./.github/actions/e2e-test-k3d
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_BRANCH: ${{ github.ref_name }}
+          TARGET_BRANCH: ${{ github.base_ref }}
         with:
           test_make_target: "upgrade-test"
           operator-version: ${{ needs.get-image.outputs.operator_version }}


### PR DESCRIPTION
(cherry picked from commit a3798f40a91cf687a74ae8edcc72044cd731cad4)

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Used proper variable (base ref) when providing target branch name to the Istio upgrade test

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.
- [x] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [x] RBAC settings are as restrictive as possible.
- [x] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [x] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.
- [x] You checked if Busola updates are needed.
- [x] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
