### PR TITLE
Main autorelease job + component-config for the main branch scanning

### DIFF
--- a/.github/workflows/post-main-autorelease.yaml
+++ b/.github/workflows/post-main-autorelease.yaml
@@ -1,0 +1,39 @@
+name: Post Main Autorelease
+
+permissions:
+  id-token: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build-image:
+    name: Build manager image
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    with:
+      name: istio/main/istio-manager
+      dockerfile: Dockerfile
+      context: .
+      build-args: |
+        VERSION=main
+      tags: main
+
+  build-image-experimental:
+    name: Build manager image - experimental
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    with:
+      name: istio/main/istio-manager
+      dockerfile: Dockerfile
+      context: .
+      build-args: |
+        VERSION=main-experimental
+        GO_BUILD_TAGS=experimental
+      tags: main-experimental

--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,0 +1,10 @@
+name: kyma-project.io/module/istio
+team: kyma/Goat
+images:
+  - europe-docker.pkg.dev/kyma-project/prod/istio/main/istio-manager:main
+  - europe-docker.pkg.dev/kyma-project/prod/external/istio/install-cni:1.29.3-distroless
+  - europe-docker.pkg.dev/kyma-project/prod/external/istio/proxyv2:1.29.3-distroless
+  - europe-docker.pkg.dev/kyma-project/prod/external/istio/pilot:1.29.3-distroless
+  - europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/istio-install-cni-fips:1.29.3-1
+  - europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/istio-proxy-fips:1.29.3-1
+  - europe-docker.pkg.dev/kyma-project/restricted-prod/external/istio/istio-pilot-fips:1.29.3-1


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- job that automatically releases new controller image from the main branch
- component-config for the main branch scanning

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.
- [ ] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
