### PR TITLE
Added information about component-config.yaml in the Istio bump template

### DIFF
--- a/.github/ISSUE_TEMPLATE/istio_update.md
+++ b/.github/ISSUE_TEMPLATE/istio_update.md
@@ -18,7 +18,8 @@ ACs:
 - [ ] Verify that the new Istio version doesn't introduce features that transition to a new [phase](https://istio.io/latest/docs/releases/feature-stages/) in Istio, potentially affecting Kyma's Istio behavior. If such changes are identified, discuss them with the team to determine the best course of action.
 - [ ] New Istio minor should be bumped on the `main` / New Istio patch should be bumped on the `main` and the latest release branch.
 - [ ] Images of the new Istio version are synced to the Kyma registry by adding them to the [external-images.yaml](https://github.com/kyma-project/istio/blob/main/external-images.yaml).
-- [ ] FIPS images of the new Istio version are synced to the restricted registry.
+- [ ] FIPS images of the new Istio version are synced to the restricted registry adding them to the [fips-images.yaml](https://github.com/kyma-project/istio/blob/main/fips-images.yaml)
+- [ ] Above images should be also updated in the [component-config.yaml](https://github.com/kyma-project/istio/blob/main/component-config.yaml)
 - [ ] Prepare Kyma runtime Istio RNs based on open-source Istio RNs.
 - [ ] Istio installs and upgrades to a new version.
 - [ ] Tests and documentation updated if needed.

--- a/.github/ISSUE_TEMPLATE/istio_update.md
+++ b/.github/ISSUE_TEMPLATE/istio_update.md
@@ -18,8 +18,8 @@ ACs:
 - [ ] Verify that the new Istio version doesn't introduce features that transition to a new [phase](https://istio.io/latest/docs/releases/feature-stages/) in Istio, potentially affecting Kyma's Istio behavior. If such changes are identified, discuss them with the team to determine the best course of action.
 - [ ] New Istio minor should be bumped on the `main` / New Istio patch should be bumped on the `main` and the latest release branch.
 - [ ] Images of the new Istio version are synced to the Kyma registry by adding them to the [external-images.yaml](https://github.com/kyma-project/istio/blob/main/external-images.yaml).
-- [ ] FIPS images of the new Istio version are synced to the restricted registry adding them to the [fips-images.yaml](https://github.com/kyma-project/istio/blob/main/fips-images.yaml)
-- [ ] Above images should be also updated in the [component-config.yaml](https://github.com/kyma-project/istio/blob/main/component-config.yaml)
+- [ ] FIPS images of the new Istio version are synced to the restricted registry by adding them to the [fips-images.yaml](https://github.com/kyma-project/istio/blob/main/fips-images.yaml).
+- [ ] The above images should also be updated in [component-config.yaml](https://github.com/kyma-project/istio/blob/main/component-config.yaml).
 - [ ] Prepare Kyma runtime Istio RNs based on open-source Istio RNs.
 - [ ] Istio installs and upgrades to a new version.
 - [ ] Tests and documentation updated if needed.


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Mentioned component-config.yaml in the Istio bump issue template

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.
- [ ] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
