### PR TITLE
Introduced a generic target for running e2e tests

### DIFF
--- a/.github/workflows/post-main-release-workflow.yaml
+++ b/.github/workflows/post-main-release-workflow.yaml
@@ -91,9 +91,9 @@ jobs:
         test-make-target:
           - "installation-e2e-test"
           - "configuration-e2e-test"
-          - "mesh-communication-e2e-test"
+          - "mesh_communication-e2e-test"
           - "observability-e2e-test"
-          - "ext-auth-e2e-test"
+          - "extauth-e2e-test"
           - "egress-e2e-test"
           - "networkpolicy-e2e-test"
     steps:
@@ -196,7 +196,7 @@ jobs:
       matrix:
         test-make-target:
           - "installation-e2e-test"
-          - "istio-smoke-test"
+          - "smoke_test-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-k3d
@@ -225,10 +225,10 @@ jobs:
       fail-fast: false
       matrix:
         test_make_target:
-          - "xff-header-e2e-test"
-          - "trust-domain-e2e-test"
+          - "xff_header-e2e-test"
+          - "trustdomain-e2e-test"
           - "networkpolicy-e2e-test"
-          - "dns-proxying-e2e-test"
+          - "dnsproxying-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener
@@ -254,9 +254,9 @@ jobs:
       matrix:
         test_make_target:
           - "xff-header-e2e-test"
-          - "trust-domain-e2e-test"
+          - "trustdomain-e2e-test"
           - "networkpolicy-e2e-test"
-          - "dns-proxying-e2e-test"
+          - "dnsproxying-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -91,13 +91,13 @@ jobs:
         test-make-target:
           - "installation-e2e-test"
           - "configuration-e2e-test"
-          - "mesh-communication-e2e-test"
+          - "mesh_communication-e2e-test"
           - "observability-e2e-test"
-          - "ext-auth-e2e-test"
+          - "extauth-e2e-test"
           - "egress-e2e-test"
-          - "trust-domain-e2e-test"
+          - "trustdomain-e2e-test"
           - "networkpolicy-e2e-test"
-          - "dns-proxying-e2e-test"
+          - "dnsproxying-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/load-manager-image

--- a/.github/workflows/release-istio.yaml
+++ b/.github/workflows/release-istio.yaml
@@ -159,9 +159,9 @@ jobs:
         test-make-target:
           - "installation-e2e-test"
           - "configuration-e2e-test"
-          - "mesh-communication-e2e-test"
+          - "mesh_communication-e2e-test"
           - "observability-e2e-test"
-          - "ext-auth-e2e-test"
+          - "extauth-e2e-test"
           - "egress-e2e-test"
           - "networkpolicy-e2e-test"
     steps:
@@ -245,7 +245,7 @@ jobs:
       matrix:
         test-make-target:
           - "installation-e2e-test"
-          - "istio-smoke-test"
+          - "smoke_test-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-k3d
@@ -293,10 +293,10 @@ jobs:
       fail-fast: false
       matrix:
         test_make_target:
-          - "xff-header-e2e-test"
-          - "trust-domain-e2e-test"
+          - "xff_header-e2e-test"
+          - "trustdomain-e2e-test"
           - "networkpolicy-e2e-test"
-          - "dns-proxying-e2e-test"
+          - "dnsproxying-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener
@@ -321,10 +321,10 @@ jobs:
       fail-fast: false
       matrix:
         test_make_target:
-          - "xff-header-e2e-test"
-          - "trust-domain-e2e-test"
+          - "xff_header-e2e-test"
+          - "trustdomain-e2e-test"
           - "networkpolicy-e2e-test"
-          - "dns-proxying-e2e-test"
+          - "dnsproxying-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener

--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -166,9 +166,9 @@ jobs:
         test-make-target:
           - "installation-e2e-test"
           - "configuration-e2e-test"
-          - "mesh-communication-e2e-test"
+          - "mesh_communication-e2e-test"
           - "observability-e2e-test"
-          - "ext-auth-e2e-test"
+          - "extauth-e2e-test"
           - "egress-e2e-test"
           - "networkpolicy-e2e-test"
     steps:
@@ -271,7 +271,7 @@ jobs:
       matrix:
         test-make-target:
           - "installation-e2e-test"
-          - "istio-smoke-test"
+          - "istio_test-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-k3d
@@ -300,10 +300,10 @@ jobs:
       fail-fast: false
       matrix:
         test_make_target:
-          - "xff-header-e2e-test"
-          - "trust-domain-e2e-test"
+          - "xff_header-e2e-test"
+          - "trustdomain-e2e-test"
           - "networkpolicy-e2e-test"
-          - "dns-proxying-e2e-test"
+          - "dnsproxying-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener
@@ -329,9 +329,9 @@ jobs:
       matrix:
         test_make_target:
           - "xff-header-e2e-test"
-          - "trust-domain-e2e-test"
+          - "trustdomain-e2e-test"
           - "networkpolicy-e2e-test"
-          - "dns-proxying-e2e-test"
+          - "dnsproxying-e2e-test"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/e2e-test-gardener

--- a/Makefile
+++ b/Makefile
@@ -228,104 +228,19 @@ ln -sf $$(realpath $(1)-$(3)) $(1)
 endef
 
 ##@ E2E Tests
-
-.PHONY: evaluation-e2e-test
-evaluation-e2e-test: gotestsum deploy
-	@echo "Running e2e evaluation settings tests"
+.PHONY: %-e2e-test
+%-e2e-test: gotestsum deploy
+	@echo "Running E2E test: $*"
 	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/evaluation/..." --junitfile "./tests/e2e/tests/evaluation/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: configuration-e2e-test
-configuration-e2e-test: gotestsum deploy
-	@echo "Running e2e configuration tests"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/configuration/..." --junitfile "./tests/e2e/tests/configuration/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: mesh-communication-e2e-test
-mesh-communication-e2e-test: gotestsum deploy
-	@echo "Running e2e mesh communication tests"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/mesh_communication/..." --junitfile "./tests/e2e/tests/mesh_communication/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: networkpolicy-e2e-test
-networkpolicy-e2e-test: gotestsum deploy
-	@echo "Running e2e NetworkPolicy tests"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/networkpolicy/..." --junitfile "./tests/e2e/tests/networkpolicy/report.xml" -- -timeout 30m
-	@echo "E2E tests completed successfully"
-
-.PHONY: installation-e2e-test
-installation-e2e-test: gotestsum deploy
-	@echo "Running e2e installation tests"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/installation/..." --junitfile "./tests/e2e/tests/installation/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: observability-e2e-test
-observability-e2e-test: gotestsum deploy
-	@echo "Running e2e tests for observability"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/observability/..." --junitfile "./tests/e2e/tests/observability/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: ext-auth-e2e-test
-ext-auth-e2e-test: gotestsum deploy
-	@echo "Running e2e tests for ext auth"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/extauth/..." --junitfile "./tests/e2e/tests/extauth/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: egress-e2e-test
-egress-e2e-test: gotestsum deploy
-	@echo "Running e2e tests for egress"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/egress/..." --junitfile "./tests/e2e/tests/egress/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: istio-smoke-test
-istio-smoke-test: gotestsum deploy
-	@echo "Running smoke test"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/smoke_test/..." --junitfile "./tests/e2e/tests/smoke_test/report.xml" -- -timeout 20m
-	@echo "Smoke test completed successfully"
-
-.PHONY: ambient-e2e-test
-ambient-e2e-test: gotestsum deploy
-	@echo "Running ambient e2e tests"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/ambient/..." --junitfile "./tests/e2e/tests/ambient/report.xml" -- -timeout 20m
-	@echo "Ambient E2E tests completed successfully"
+	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/$*/..." --junitfile "./tests/e2e/tests/$*/report.xml" -- -timeout 20m
+	@echo "Finished E2E test: $*"
 
 .PHONY: upgrade-test
 upgrade-test: generate-upgrade-test-manifest deploy-latest-release gotestsum
-	@echo "Running e2e controller upgrade tests"
+	@echo "Running Upgrade test"
 	go clean -testcache
 	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/upgrade/..." --junitfile "./tests/e2e/tests/upgrade/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: xff-header-e2e-test
-xff-header-e2e-test: gotestsum deploy
-	@echo "Running e2e tests for XFF header"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/xff_header/..." --junitfile "./tests/e2e/tests/xff_header/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: trust-domain-e2e-test
-trust-domain-e2e-test: gotestsum deploy
-	@echo "Running e2e tests for trust domain"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/trustdomain/..." --junitfile "./tests/e2e/tests/trustdomain/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
-
-.PHONY: dns-proxying-e2e-test
-dns-proxying-e2e-test: gotestsum deploy
-	@echo "Running e2e tests for DNS proxying"
-	go clean -testcache
-	$(GOTESTSUM) --format testname --rerun-fails --packages="./tests/e2e/tests/dnsproxying/..." --junitfile "./tests/e2e/tests/dnsproxying/report.xml" -- -timeout 20m
-	@echo "E2E tests completed successfully"
+	@echo "Finished upgrade test"
 
 ##@ Module
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Introduced a generic target for running e2e tests

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.
- [ ] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
