### PR TITLE
bug: fix field name in comp tests

### DIFF
--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-make-target:
+        test_make_target:
           - "installation-e2e-test"
           - "configuration-e2e-test"
           - "mesh-communication-e2e-test"
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-make-target:
+        test_make_target:
           - "installation-e2e-test"
           - "configuration-e2e-test"
           - "mesh-communication-e2e-test"


### PR DESCRIPTION
`test-make-target` is incorrect, we need to change to `test_make_target`.

#2092 