### PR TITLE
hack: ignore 'componentstatuses' from API

### DIFF
--- a/.github/actions/k8s-compatibility-test-aws/action.yaml
+++ b/.github/actions/k8s-compatibility-test-aws/action.yaml
@@ -63,7 +63,7 @@ runs:
         name: html-reports_${{ github.job }}_${{ github.action }}_${{ inputs.test_make_target }}
         path: tests/integration/reports/
     - name: Check that deprecations are empty
-      run: if [[ $(cat deprecations.txt | jq 'select(.resource != "endpoints")') ]]; then exit 1; fi # we ignore endpoints as Gardener makes a request to this deprecated (since v1.33) k8s resource, see: https://github.com/gardener/gardener/issues/12154
+      run: if [[ $(cat deprecations.txt | jq 'select(.resource != "endpoints" and .resource != "componentstatuses")') ]]; then exit 1; fi # we ignore endpoints as Gardener makes a request to this deprecated (since v1.33) k8s resource, see: https://github.com/gardener/gardener/issues/12154
       shell: bash
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/k8s-compatibility-test/action.yaml
+++ b/.github/actions/k8s-compatibility-test/action.yaml
@@ -43,7 +43,7 @@ runs:
         name: html-reports-${{ github.job }}-${{ inputs.test_make_target }}
         path: tests/integration/reports/
     - name: Check that deprecations are empty
-      run: if [[ $(cat deprecations.txt | jq 'select(.resource != "endpoints")') ]]; then exit 1; fi # we ignore endpoints as k3d/k3s makes a request to this deprecated (since v1.33) k8s resource 
+      run: if [[ $(cat deprecations.txt | jq 'select(.resource != "endpoints" and .resource != "componentstatuses")') ]]; then exit 1; fi # we ignore endpoints as k3d/k3s makes a request to this deprecated (since v1.33) k8s resource
       shell: bash
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This resource seems like is showing up randomly, failing jobs.
Ignore it, since we don't reference it in runtime.
#2092 