### PR TITLE
Requeue reconciliation

### DIFF
--- a/docs/release-notes/1.28.0.md
+++ b/docs/release-notes/1.28.0.md
@@ -10,3 +10,4 @@ See [Alpha Istio Features](../user/00-45-istio-features-configmap.md). See [#201
 ## Fixed Bugs
 
 - We've fixed an issue where Gardener was not properly detected.
+- We've improved reconciliation error handling by distinguishing between warning and error states. Warning-level errors now trigger graceful requeuing with a fixed interval, while error-level errors continue to use the default exponential backoff. See [#2112](https://github.com/kyma-project/istio/pull/2112).

--- a/internal/controller/istio_controller.go
+++ b/internal/controller/istio_controller.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/kyma-project/istio/operator/internal/images"
 	istiocrmetrics "github.com/kyma-project/istio/operator/internal/metrics"
 	"github.com/kyma-project/istio/operator/internal/resources"
-	"github.com/pkg/errors"
 
 	"github.com/kyma-project/istio/operator/internal/restarter"
 	"github.com/kyma-project/istio/operator/internal/restarter/predicates"
@@ -81,7 +82,14 @@ func NewController(mgr manager.Manager, options ControllerOptions) *IstioReconci
 	actionRestarter := restart.NewActionRestarter(mgr.GetClient(), &logger)
 	restarters := []restarter.Restarter{
 		restarter.NewIngressGatewayRestarter(mgr.GetClient(), []predicates.IngressGatewayPredicate{}, statusHandler),
-		restarter.NewSidecarsRestarter(mgr.GetLogger(), mgr.GetClient(), &merger, sidecars.NewProxyRestarter(mgr.GetClient(), podsLister, actionRestarter, &logger), statusHandler, options.IstioImages),
+		restarter.NewSidecarsRestarter(
+			mgr.GetLogger(),
+			mgr.GetClient(),
+			&merger,
+			sidecars.NewProxyRestarter(mgr.GetClient(), podsLister, actionRestarter, &logger),
+			statusHandler,
+			options.IstioImages,
+		),
 		restarter.NewForNetworkPolicy(mgr.GetClient(), statusHandler),
 	}
 	userResources := resources.NewUserResources(mgr.GetClient())
@@ -284,7 +292,8 @@ func (r *IstioReconciler) requeueReconciliation(ctx context.Context,
 		if statusUpdateErr != nil {
 			r.log.Error(statusUpdateErr, "Error during updating status to error")
 		}
-		r.log.Info("Reconcile requeued")
+		r.log.Info("Reconcile warning:", "error", err)
+		r.log.Info("Reconcile requeued with a warning", "requeueAfter", requeueAfter)
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 	statusUpdateErr := r.statusHandler.UpdateToError(ctx, istioCR, err)

--- a/internal/controller/istio_controller.go
+++ b/internal/controller/istio_controller.go
@@ -279,7 +279,15 @@ func (r *IstioReconciler) requeueReconciliation(ctx context.Context,
 	if err.ShouldSetCondition() {
 		r.setConditionForError(istioCR, reason)
 	}
-	statusUpdateErr := r.statusHandler.UpdateToError(ctx, istioCR, err, requeueAfter)
+	if err.Level() == describederrors.Warning {
+		statusUpdateErr := r.statusHandler.UpdateToError(ctx, istioCR, err, requeueAfter)
+		if statusUpdateErr != nil {
+			r.log.Error(statusUpdateErr, "Error during updating status to error")
+		}
+		r.log.Info("Reconcile requeued")
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
+	statusUpdateErr := r.statusHandler.UpdateToError(ctx, istioCR, err)
 	if statusUpdateErr != nil {
 		r.log.Error(statusUpdateErr, "Error during updating status to error")
 	}

--- a/internal/controller/istio_controller.go
+++ b/internal/controller/istio_controller.go
@@ -292,7 +292,7 @@ func (r *IstioReconciler) requeueReconciliation(ctx context.Context,
 		if statusUpdateErr != nil {
 			r.log.Error(statusUpdateErr, "Error during updating status to error")
 		}
-		r.log.Info("Reconcile warning:", "error", err)
+		r.log.Info("Reconcile warning:", "warning", err)
 		r.log.Info("Reconcile requeued with a warning", "requeueAfter", requeueAfter)
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}

--- a/internal/controller/istio_controller_test.go
+++ b/internal/controller/istio_controller_test.go
@@ -763,10 +763,11 @@ var _ = Describe("Istio Controller", func() {
 			}
 
 			// when
-			_, err := sut.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: istioCrName}})
+			result, err := sut.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: istioCrName}})
 
 			// then
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(reconciliationRequeueTimeWarning))
 
 			updatedIstioCR := operatorv1alpha2.Istio{}
 			err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(istioCR), &updatedIstioCR)


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Distinguish between error and warning in `RequeueReconciliarion` function
- Use default exponential backoff on error
- Use default requeue time on warning and show it in logs

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.

**Related issues**
#1873 