### PR TITLE
feat: move AWS annotation handling to factory

### DIFF
--- a/docs/release-notes/1.29.0.md
+++ b/docs/release-notes/1.29.0.md
@@ -1,0 +1,4 @@
+
+## Enhancements
+
+- We've centralized AWS Load Balancer service annotation handling into the AWS factory, emitting only annotations effective for the detected load balancer type. See [#2128](https://github.com/kyma-project/istio/pull/2128).

--- a/internal/clusterconfig/clusterconfig_experimental_test.go
+++ b/internal/clusterconfig/clusterconfig_experimental_test.go
@@ -31,7 +31,7 @@ var awsNLBDualStackConfig = clusterconfig.ClusterConfiguration(map[string]interf
 				"istio-ingressgateway": map[string]interface{}{
 					"serviceAnnotations": map[string]string{
 						"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
-						"service.beta.kubernetes.io/aws-load-balancer-type":            "nlb",
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
 						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
 						"service.beta.kubernetes.io/aws-load-balancer-proxy-protocol":  "*",
 					},

--- a/internal/clusterconfig/clusterconfig_experimental_test.go
+++ b/internal/clusterconfig/clusterconfig_experimental_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/kyma-project/istio/operator/internal/clusterconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestIsDualStackEnabled_Experimental(t *testing.T) {
@@ -18,4 +22,58 @@ func TestIsDualStackEnabled_Experimental(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, ds)
+}
+
+var awsNLBDualStackConfig = clusterconfig.ClusterConfiguration(map[string]interface{}{
+	"spec": map[string]interface{}{
+		"values": map[string]interface{}{
+			"gateways": map[string]interface{}{
+				"istio-ingressgateway": map[string]interface{}{
+					"serviceAnnotations": map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "nlb",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+						"service.beta.kubernetes.io/aws-load-balancer-proxy-protocol":  "*",
+					},
+				},
+			},
+		},
+	},
+})
+
+func TestDiscoverClusterProvider_Experimental(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []client.Object
+		want    clusterconfig.ClusterConfiguration
+	}{
+		{
+			name: "AWS uses NLB when dualstack is enabled and ingressgateway is nil",
+			objects: []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "aws-123"},
+					Spec:       corev1.NodeSpec{ProviderID: "aws://asdasdads"},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "kyma-provisioning-info", Namespace: "kyma-system"},
+					Data: map[string]string{
+						"details": `networkDetails:
+    dualStackIPEnabled: true`,
+					},
+				},
+			},
+			want: awsNLBDualStackConfig,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := createFakeClient(t, tt.objects...)
+
+			str, err := clusterconfig.BuildFactory(context.Background(), c)
+			require.NoError(t, err)
+			got := clusterconfig.ClusterConfigurationFromFactory(str)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -206,8 +206,9 @@ var awsNLBConfig = clusterconfig.ClusterConfiguration(map[string]interface{}{
 			"gateways": map[string]interface{}{
 				"istio-ingressgateway": map[string]interface{}{
 					"serviceAnnotations": map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
-						"service.beta.kubernetes.io/aws-load-balancer-type":   "nlb",
+						"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "nlb",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
 					},
 				},
 			},

--- a/internal/clusterconfig/clusterconfig_test.go
+++ b/internal/clusterconfig/clusterconfig_test.go
@@ -206,9 +206,23 @@ var awsNLBConfig = clusterconfig.ClusterConfiguration(map[string]interface{}{
 			"gateways": map[string]interface{}{
 				"istio-ingressgateway": map[string]interface{}{
 					"serviceAnnotations": map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
-						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
-						"service.beta.kubernetes.io/aws-load-balancer-type":            "nlb",
+						"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+						"service.beta.kubernetes.io/aws-load-balancer-type":   "nlb",
+					},
+				},
+			},
+		},
+	},
+})
+
+var awsELBConfig = clusterconfig.ClusterConfiguration(map[string]interface{}{
+	"spec": map[string]interface{}{
+		"values": map[string]interface{}{
+			"gateways": map[string]interface{}{
+				"istio-ingressgateway": map[string]interface{}{
+					"serviceAnnotations": map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-proxy-protocol":          "*",
+						"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "4000",
 					},
 				},
 			},
@@ -314,9 +328,8 @@ func TestEvaluateClusterConfiguration(t *testing.T) {
 						Name:      "istio-ingressgateway",
 						Namespace: "istio-system",
 						Annotations: map[string]string{
-							"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
-							"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
-							"service.beta.kubernetes.io/aws-load-balancer-type":            "nlb",
+							"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+							"service.beta.kubernetes.io/aws-load-balancer-type":   "nlb",
 						},
 					},
 				},
@@ -334,7 +347,7 @@ func TestEvaluateClusterConfiguration(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{Name: "elb-deprecated", Namespace: "istio-system"},
 				},
 			},
-			want: emptyValuesConfig,
+			want: awsELBConfig,
 		},
 		{
 			name: "GKE sets cni values",

--- a/internal/clusterconfig/experimental.go
+++ b/internal/clusterconfig/experimental.go
@@ -1,7 +1,7 @@
-//go:build !experimental
+//go:build experimental
 
 package clusterconfig
 
 func isExperimentalEnabled() bool {
-	return false
+	return true
 }

--- a/internal/clusterconfig/factory/aws/aws.go
+++ b/internal/clusterconfig/factory/aws/aws.go
@@ -10,12 +10,16 @@ import (
 )
 
 const (
-	LBTypeAnnotation        = "service.beta.kubernetes.io/aws-load-balancer-type"
-	NLBType                 = "nlb"
-	NlbTargetTypeAnnotation = "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"
-	NlbTargetTypeInstance   = "instance"
-	SchemeAnnotation        = "service.beta.kubernetes.io/aws-load-balancer-scheme"
-	InternetFacingScheme    = "internet-facing"
+	ProxyProtocolAnnotation   = "service.beta.kubernetes.io/aws-load-balancer-proxy-protocol"
+	ProxyProtocolValue        = "*"
+	ConnIdleTimeoutAnnotation = "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"
+	ConnIdleTimeoutValue      = "4000"
+	LBTypeAnnotation          = "service.beta.kubernetes.io/aws-load-balancer-type"
+	NLBType                   = "nlb"
+	NlbTargetTypeAnnotation   = "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"
+	NlbTargetTypeInstance     = "instance"
+	SchemeAnnotation          = "service.beta.kubernetes.io/aws-load-balancer-scheme"
+	InternetFacingScheme      = "internet-facing"
 
 	istioIngressNamespace   = "istio-system"
 	istioIngressServiceName = "istio-ingressgateway"
@@ -45,20 +49,36 @@ type LB struct {
 }
 
 func (s *LB) Annotations() map[string]string {
-	if s.lbType == ELB {
-		return nil
+	if s.lbType == NLB {
+		// AWS LBC
+		// In case of running with DualStack IP family,
+		// The annotation "service.beta.kubernetes.io/aws-load-balancer-ip-address-type=dualstack" is required.
+		// AWS LB Controller-style annotations (type=external, ip-address-type=dualstack)
+		// are intentionally NOT emitted here. On Gardener IPv6/dual-stack clusters those
+		// are added by Gardener's shoot-service mutating webhook. See:
+		// https://github.com/gardener/gardener-extension-provider-aws/blob/master/pkg/webhook/shootservice/mutator.go
+		// Switching IPv4 clusters to LB type=external is a potential follow up.
+		if s.stackType == DualStack {
+			return map[string]string{
+				LBTypeAnnotation:        NLBType,
+				SchemeAnnotation:        InternetFacingScheme,
+				NlbTargetTypeAnnotation: NlbTargetTypeInstance,
+				ProxyProtocolAnnotation: ProxyProtocolValue,
+			}
+		}
+		// in-tree AWS CCM
+		if s.stackType == IPv4 {
+			return map[string]string{
+				LBTypeAnnotation: NLBType,
+				SchemeAnnotation: InternetFacingScheme,
+			}
+		}
 	}
-	// In case of running with DualStack IP family,
-	// The annotation "service.beta.kubernetes.io/aws-load-balancer-ip-address-type=dualstack" is required.
-	// AWS LB Controller-style annotations (type=external, ip-address-type=dualstack)
-	// are intentionally NOT emitted here. On Gardener IPv6/dual-stack clusters those
-	// are added by Gardener's shoot-service mutating webhook. See:
-	// https://github.com/gardener/gardener-extension-provider-aws/blob/master/pkg/webhook/shootservice/mutator.go
-	// Switching IPv4 clusters to LB type=external is a potential follow up.
+
+	// ELB
 	return map[string]string{
-		LBTypeAnnotation:        NLBType,
-		SchemeAnnotation:        InternetFacingScheme,
-		NlbTargetTypeAnnotation: NlbTargetTypeInstance,
+		ProxyProtocolAnnotation:   ProxyProtocolValue,
+		ConnIdleTimeoutAnnotation: ConnIdleTimeoutValue,
 	}
 }
 

--- a/internal/clusterconfig/factory/aws/aws.go
+++ b/internal/clusterconfig/factory/aws/aws.go
@@ -16,6 +16,7 @@ const (
 	ConnIdleTimeoutValue      = "4000"
 	LBTypeAnnotation          = "service.beta.kubernetes.io/aws-load-balancer-type"
 	NLBType                   = "nlb"
+	ExternalType              = "external"
 	NlbTargetTypeAnnotation   = "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"
 	NlbTargetTypeInstance     = "instance"
 	SchemeAnnotation          = "service.beta.kubernetes.io/aws-load-balancer-scheme"
@@ -61,7 +62,7 @@ func (s *LB) Annotations() map[string]string {
 		// Switching IPv4 clusters to LB type=external is a potential follow up.
 		if s.stackType == DualStack {
 			return map[string]string{
-				LBTypeAnnotation:        NLBType,
+				LBTypeAnnotation:        ExternalType,
 				SchemeAnnotation:        InternetFacingScheme,
 				NlbTargetTypeAnnotation: NlbTargetTypeInstance,
 				ProxyProtocolAnnotation: ProxyProtocolValue,

--- a/internal/clusterconfig/factory/aws/aws.go
+++ b/internal/clusterconfig/factory/aws/aws.go
@@ -49,6 +49,7 @@ type LB struct {
 }
 
 func (s *LB) Annotations() map[string]string {
+
 	if s.lbType == NLB {
 		// AWS LBC
 		// In case of running with DualStack IP family,
@@ -69,8 +70,9 @@ func (s *LB) Annotations() map[string]string {
 		// in-tree AWS CCM
 		if s.stackType == IPv4 {
 			return map[string]string{
-				LBTypeAnnotation: NLBType,
-				SchemeAnnotation: InternetFacingScheme,
+				LBTypeAnnotation:        NLBType,
+				SchemeAnnotation:        InternetFacingScheme,
+				NlbTargetTypeAnnotation: NlbTargetTypeInstance,
 			}
 		}
 	}

--- a/internal/clusterconfig/factory/aws/aws_test.go
+++ b/internal/clusterconfig/factory/aws/aws_test.go
@@ -50,8 +50,9 @@ func TestFactory_MakeLB(t *testing.T) {
 			objs:             nil,
 			dualStackEnabled: false,
 			wantAnnots: map[string]string{
-				aws.LBTypeAnnotation: aws.NLBType,
-				aws.SchemeAnnotation: aws.InternetFacingScheme,
+				aws.LBTypeAnnotation:        aws.NLBType,
+				aws.SchemeAnnotation:        aws.InternetFacingScheme,
+				aws.NlbTargetTypeAnnotation: aws.NlbTargetTypeInstance,
 			},
 		},
 		{
@@ -73,8 +74,9 @@ func TestFactory_MakeLB(t *testing.T) {
 			},
 			dualStackEnabled: false,
 			wantAnnots: map[string]string{
-				aws.LBTypeAnnotation: aws.NLBType,
-				aws.SchemeAnnotation: aws.InternetFacingScheme,
+				aws.LBTypeAnnotation:        aws.NLBType,
+				aws.SchemeAnnotation:        aws.InternetFacingScheme,
+				aws.NlbTargetTypeAnnotation: aws.NlbTargetTypeInstance,
 			},
 		},
 		{

--- a/internal/clusterconfig/factory/aws/aws_test.go
+++ b/internal/clusterconfig/factory/aws/aws_test.go
@@ -60,7 +60,7 @@ func TestFactory_MakeLB(t *testing.T) {
 			objs:             nil,
 			dualStackEnabled: true,
 			wantAnnots: map[string]string{
-				aws.LBTypeAnnotation:        aws.NLBType,
+				aws.LBTypeAnnotation:        aws.ExternalType,
 				aws.SchemeAnnotation:        aws.InternetFacingScheme,
 				aws.NlbTargetTypeAnnotation: aws.NlbTargetTypeInstance,
 				aws.ProxyProtocolAnnotation: aws.ProxyProtocolValue,

--- a/internal/clusterconfig/factory/aws/aws_test.go
+++ b/internal/clusterconfig/factory/aws/aws_test.go
@@ -50,26 +50,20 @@ func TestFactory_MakeLB(t *testing.T) {
 			objs:             nil,
 			dualStackEnabled: false,
 			wantAnnots: map[string]string{
-				aws.LBTypeAnnotation:        aws.NLBType,
-				aws.SchemeAnnotation:        aws.InternetFacingScheme,
-				aws.NlbTargetTypeAnnotation: aws.NlbTargetTypeInstance,
+				aws.LBTypeAnnotation: aws.NLBType,
+				aws.SchemeAnnotation: aws.InternetFacingScheme,
 			},
 		},
 		{
-			name:             "no elb-deprecated CM + dualStack -> NLB",
+			name:             "no elb-deprecated CM + dualStack -> NLB with proxy-protocol annotations",
 			objs:             nil,
 			dualStackEnabled: true,
 			wantAnnots: map[string]string{
 				aws.LBTypeAnnotation:        aws.NLBType,
 				aws.SchemeAnnotation:        aws.InternetFacingScheme,
 				aws.NlbTargetTypeAnnotation: aws.NlbTargetTypeInstance,
+				aws.ProxyProtocolAnnotation: aws.ProxyProtocolValue,
 			},
-		},
-		{
-			name:             "elb-deprecated CM present, no service -> ELB (no annotations)",
-			objs:             []client.Object{elbDeprecatedCM()},
-			dualStackEnabled: false,
-			wantAnnots:       nil,
 		},
 		{
 			name: "elb-deprecated CM present + service already NLB -> NLB",
@@ -79,9 +73,8 @@ func TestFactory_MakeLB(t *testing.T) {
 			},
 			dualStackEnabled: false,
 			wantAnnots: map[string]string{
-				aws.LBTypeAnnotation:        aws.NLBType,
-				aws.SchemeAnnotation:        aws.InternetFacingScheme,
-				aws.NlbTargetTypeAnnotation: aws.NlbTargetTypeInstance,
+				aws.LBTypeAnnotation: aws.NLBType,
+				aws.SchemeAnnotation: aws.InternetFacingScheme,
 			},
 		},
 		{
@@ -91,7 +84,9 @@ func TestFactory_MakeLB(t *testing.T) {
 				ingressGatewaySvc(map[string]string{aws.LBTypeAnnotation: "classic"}),
 			},
 			dualStackEnabled: false,
-			wantAnnots:       nil,
+			wantAnnots: map[string]string{
+				aws.ProxyProtocolAnnotation:   aws.ProxyProtocolValue,
+				aws.ConnIdleTimeoutAnnotation: aws.ConnIdleTimeoutValue},
 		},
 		{
 			name: "elb-deprecated CM present + service without LB annotation -> ELB",
@@ -100,7 +95,9 @@ func TestFactory_MakeLB(t *testing.T) {
 				ingressGatewaySvc(nil),
 			},
 			dualStackEnabled: false,
-			wantAnnots:       nil,
+			wantAnnots: map[string]string{
+				aws.ProxyProtocolAnnotation:   aws.ProxyProtocolValue,
+				aws.ConnIdleTimeoutAnnotation: aws.ConnIdleTimeoutValue},
 		},
 	}
 

--- a/internal/clusterconfig/regular.go
+++ b/internal/clusterconfig/regular.go
@@ -1,7 +1,7 @@
-//go:build experimental
+//go:build !experimental
 
 package clusterconfig
 
 func isExperimentalEnabled() bool {
-	return true
+	return false
 }

--- a/internal/istiooperator/istio-operator-light.yaml
+++ b/internal/istiooperator/istio-operator-light.yaml
@@ -301,8 +301,6 @@ spec:
           name: ingressgateway-ca-certs
           secretName: istio-ingressgateway-ca-certs
         serviceAnnotations:
-          service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-          service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
           istios.operator.kyma-project.io/managed-by-disclaimer: |
             DO NOT EDIT - This resource is managed by Kyma.
             Any modifications are discarded and the resource is reverted to the original state.

--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -355,8 +355,6 @@ spec:
           name: ingressgateway-ca-certs
           secretName: istio-ingressgateway-ca-certs
         serviceAnnotations:
-          service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-          service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
           istios.operator.kyma-project.io/managed-by-disclaimer: |
             DO NOT EDIT - This resource is managed by Kyma.
             Any modifications are discarded and the resource is reverted to the original state.


### PR DESCRIPTION
feat: move AWS annotation handling to factory

- remove annotations from shared YAMLs
- move AWS LB-specific annotation handling to aws factory

#2119