### PR TITLE
Add TSC

### DIFF
--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -158,6 +158,20 @@ spec:
           patches:
             - path: spec.template.metadata.labels.kyma-project\.io/module
               value: istio
+            - path: spec.template.spec.topologySpreadConstraints
+              value:
+                - maxSkew: 1
+                  topologyKey: kubernetes.io/hostname
+                  whenUnsatisfiable: DoNotSchedule
+                  labelSelector:
+                    matchLabels:
+                      app: istio-ingressgateway
+                - maxSkew: 1
+                  topologyKey: topology.kubernetes.io/zone
+                  whenUnsatisfiable: ScheduleAnyway
+                  labelSelector:
+                    matchLabels:
+                      app: istio-ingressgateway
       name: istio-ingressgateway
     istiodRemote:
       enabled: false

--- a/internal/istiooperator/istio-operator.yaml
+++ b/internal/istiooperator/istio-operator.yaml
@@ -97,6 +97,8 @@ spec:
     ingressGateways:
     - enabled: true
       k8s:
+        podDisruptionBudget:
+          maxUnavailable: 1
         podAnnotations:
           sidecar.istio.io/statsEvictionInterval: "6h"
         affinity:

--- a/tests/e2e/pkg/asserts/istio/resource_readiness_assertions.go
+++ b/tests/e2e/pkg/asserts/istio/resource_readiness_assertions.go
@@ -103,8 +103,8 @@ func AssertDefaultPeerAuthenticationExists(t *testing.T, c *resources.Resources)
 	return pa
 }
 
-// AssertPodDisruptionBudgetReady asserts that the PodDisruptionBudget exists in the given namespace and has the expected minAvailable value
-func AssertPodDisruptionBudgetReady(t *testing.T, c *resources.Resources, name, namespace string, expectedMinAvailable int32) {
+// AssertPodDisruptionBudgetMinAvailable asserts that the PodDisruptionBudget exists in the given namespace and has the expected minAvailable value
+func AssertPodDisruptionBudgetMinAvailable(t *testing.T, c *resources.Resources, name, namespace string, expectedMinAvailable int32) {
 	t.Helper()
 
 	pdb := &policyv1.PodDisruptionBudget{}
@@ -113,5 +113,18 @@ func AssertPodDisruptionBudgetReady(t *testing.T, c *resources.Resources, name, 
 
 	require.NotNil(t, pdb.Spec.MinAvailable, "PDB %s/%s has no MinAvailable", namespace, name)
 	require.Equal(t, expectedMinAvailable, pdb.Spec.MinAvailable.IntVal, "PDB %s/%s MinAvailable mismatch", namespace, name)
+	require.NotNil(t, pdb.Spec.Selector, "PDB %s/%s has no selector", namespace, name)
+}
+
+// AssertPodDisruptionBudgetMaxUnavailable asserts that the PodDisruptionBudget exists in the given namespace and has the expected maxUnavailable value
+func AssertPodDisruptionBudgetMaxUnavailable(t *testing.T, c *resources.Resources, name, namespace string, expectedMaxUnavailable int32) {
+	t.Helper()
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := c.Get(t.Context(), name, namespace, pdb)
+	require.NoError(t, err)
+
+	require.NotNil(t, pdb.Spec.MaxUnavailable, "PDB %s/%s has no MaxUnavailable", namespace, name)
+	require.Equal(t, expectedMaxUnavailable, pdb.Spec.MaxUnavailable.IntVal, "PDB %s/%s MaxUnavailable mismatch", namespace, name)
 	require.NotNil(t, pdb.Spec.Selector, "PDB %s/%s has no selector", namespace, name)
 }

--- a/tests/e2e/tests/installation/installation_test.go
+++ b/tests/e2e/tests/installation/installation_test.go
@@ -61,8 +61,8 @@ func TestInstallation(t *testing.T) {
 		}
 
 		istioassert.AssertIstiodPodResources(t, c, "100m", "512Mi", "4000m", "2048Mi")
-		istioassert.AssertPodDisruptionBudgetReady(t, c, "istiod", "istio-system", 1)
-		istioassert.AssertPodDisruptionBudgetReady(t, c, "istio-ingressgateway", "istio-system", 1)
+		istioassert.AssertPodDisruptionBudgetMinAvailable(t, c, "istiod", "istio-system", 1)
+		istioassert.AssertPodDisruptionBudgetMaxUnavailable(t, c, "istio-ingressgateway", "istio-system", 1)
 	})
 
 	t.Run("Installation of Istio module with custom values", func(t *testing.T) {
@@ -109,8 +109,8 @@ func TestInstallation(t *testing.T) {
 		istioassert.AssertIngressGatewayPodResources(t, c, "80m", "200Mi", "1500m", "1200Mi")
 		istioassert.AssertEgressGatewayPodResources(t, c, "70m", "190Mi", "1400m", "1100Mi")
 
-		istioassert.AssertPodDisruptionBudgetReady(t, c, "istiod", "istio-system", 1)
-		istioassert.AssertPodDisruptionBudgetReady(t, c, "istio-ingressgateway", "istio-system", 1)
+		istioassert.AssertPodDisruptionBudgetMinAvailable(t, c, "istiod", "istio-system", 1)
+		istioassert.AssertPodDisruptionBudgetMaxUnavailable(t, c, "istio-ingressgateway", "istio-system", 1)
 	})
 
 	t.Run("Managed Istio resources are present", func(t *testing.T) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `topologySpreadConstraints` to the `istio-ingressgateway` Deployment to harden replica spreading across nodes and zones, reducing customer workload disruption during node machine-type upgrades (node rolls).
- Constraints: hard `maxSkew: 1` / `whenUnsatisfiable: DoNotSchedule` on `kubernetes.io/hostname` (never two ingressgateway replicas on the same node) and soft `maxSkew: 1` / `whenUnsatisfiable: ScheduleAnyway` on `topology.kubernetes.io/zone`.
- Injected through the existing `k8s.overlays` Deployment patch in `internal/istiooperator/istio-operator.yaml` (regular profile), since Istio's gateway `k8s` API does not expose `topologySpreadConstraints` as a first-class field.
- The existing soft `podAntiAffinity` is kept as an additional scheduling hint; the rolling-update strategy is unchanged.
- Light/evaluation profile is not modified (single replica, spread constraints have no effect).

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.
- [ ] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**

None