### PR TITLE
Add proxy stats matcher validation and restarter to ingress gateway

### DIFF
--- a/api/v1alpha2/istio_structs.go
+++ b/api/v1alpha2/istio_structs.go
@@ -49,7 +49,7 @@ type Config struct {
 
 	// Configures which Istio proxy stats are emitted by matching stat names against inclusion regular expressions.
 	// Stats whose names do not match any of the configured inclusion patterns are not emitted by the proxy.
-	// For more information, see https://istio.io/latest/docs/ops/configuration/telemetry/envoy-stats/
+	// For more information, see [Envoy Statistics](https://istio.io/latest/docs/ops/configuration/telemetry/envoy-stats/).
 	// +kubebuilder:validation:Optional
 	ProxyStatsMatcher *ProxyStatsMatcher `json:"proxyStatsMatcher,omitempty"`
 }

--- a/api/v1alpha2/istio_structs.go
+++ b/api/v1alpha2/istio_structs.go
@@ -49,6 +49,7 @@ type Config struct {
 
 	// Configures which Istio proxy stats are emitted by matching stat names against inclusion regular expressions.
 	// Stats whose names do not match any of the configured inclusion patterns are not emitted by the proxy.
+	// For more information, see https://istio.io/latest/docs/ops/configuration/telemetry/envoy-stats/
 	// +kubebuilder:validation:Optional
 	ProxyStatsMatcher *ProxyStatsMatcher `json:"proxyStatsMatcher,omitempty"`
 }

--- a/config/crd/bases/operator.kyma-project.io_istios.yaml
+++ b/config/crd/bases/operator.kyma-project.io_istios.yaml
@@ -1527,7 +1527,7 @@ spec:
                     description: |-
                       Configures which Istio proxy stats are emitted by matching stat names against inclusion regular expressions.
                       Stats whose names do not match any of the configured inclusion patterns are not emitted by the proxy.
-                      For more information, see https://istio.io/latest/docs/ops/configuration/telemetry/envoy-stats/
+                      For more information, see [Envoy Statistics](https://istio.io/latest/docs/ops/configuration/telemetry/envoy-stats/).
                     properties:
                       inclusionRegexps:
                         description: |-

--- a/config/crd/bases/operator.kyma-project.io_istios.yaml
+++ b/config/crd/bases/operator.kyma-project.io_istios.yaml
@@ -1527,6 +1527,7 @@ spec:
                     description: |-
                       Configures which Istio proxy stats are emitted by matching stat names against inclusion regular expressions.
                       Stats whose names do not match any of the configured inclusion patterns are not emitted by the proxy.
+                      For more information, see https://istio.io/latest/docs/ops/configuration/telemetry/envoy-stats/
                     properties:
                       inclusionRegexps:
                         description: |-

--- a/docs/user/04-00-istio-custom-resource.md
+++ b/docs/user/04-00-istio-custom-resource.md
@@ -141,7 +141,7 @@ Appears in:
 | **telemetry** <br /> [Telemetry](#telemetry) | Defines the telemetry configuration of Istio. | Optional <br /> |
 | **trustDomain** <br /> string | Defines trust domain configuration of Istio. | MaxLength: 255 <br />MinLength: 1 <br />Optional <br />Pattern: `^[a-z0-9]*([a-z0-9-_]*)?(\.[a-z0-9]*([a-z0-9-_]*[a-z0-9]*)?)*$` <br /> |
 | **enableDNSProxying** <br /> boolean | Enables or disables global DNS proxying in Istio sidecar and gateway proxies across the service mesh.<br />When enabled, DNS requests from application Pods are intercepted by Istio proxies<br />instead of being sent directly to upstream DNS servers.<br />Enabling this setting allows Istio proxies to distinguish traffic between two different TCP services that are outside the mesh thanks to virtual IP address assignment to each ServiceEntry from reserved IP range 240.240.0.0/16. | Optional <br /> |
-| **proxyStatsMatcher** <br /> [ProxyStatsMatcher](#proxystatsmatcher) | Configures which Istio proxy stats are emitted by matching stat names against inclusion regular expressions.<br />Stats whose names do not match any of the configured inclusion patterns are not emitted by the proxy. | Optional <br /> |
+| **proxyStatsMatcher** <br /> [ProxyStatsMatcher](#proxystatsmatcher) | Configures which Istio proxy stats are emitted by matching stat names against inclusion regular expressions.<br />Stats whose names do not match any of the configured inclusion patterns are not emitted by the proxy.<br />For more information, see https://istio.io/latest/docs/ops/configuration/telemetry/envoy-stats/ | Optional <br /> |
 
 ### EgressGateway
 

--- a/docs/user/04-00-istio-custom-resource.md
+++ b/docs/user/04-00-istio-custom-resource.md
@@ -141,7 +141,7 @@ Appears in:
 | **telemetry** <br /> [Telemetry](#telemetry) | Defines the telemetry configuration of Istio. | Optional <br /> |
 | **trustDomain** <br /> string | Defines trust domain configuration of Istio. | MaxLength: 255 <br />MinLength: 1 <br />Optional <br />Pattern: `^[a-z0-9]*([a-z0-9-_]*)?(\.[a-z0-9]*([a-z0-9-_]*[a-z0-9]*)?)*$` <br /> |
 | **enableDNSProxying** <br /> boolean | Enables or disables global DNS proxying in Istio sidecar and gateway proxies across the service mesh.<br />When enabled, DNS requests from application Pods are intercepted by Istio proxies<br />instead of being sent directly to upstream DNS servers.<br />Enabling this setting allows Istio proxies to distinguish traffic between two different TCP services that are outside the mesh thanks to virtual IP address assignment to each ServiceEntry from reserved IP range 240.240.0.0/16. | Optional <br /> |
-| **proxyStatsMatcher** <br /> [ProxyStatsMatcher](#proxystatsmatcher) | Configures which Istio proxy stats are emitted by matching stat names against inclusion regular expressions.<br />Stats whose names do not match any of the configured inclusion patterns are not emitted by the proxy.<br />For more information, see https://istio.io/latest/docs/ops/configuration/telemetry/envoy-stats/ | Optional <br /> |
+| **proxyStatsMatcher** <br /> [ProxyStatsMatcher](#proxystatsmatcher) | Configures which Istio proxy stats are emitted by matching stat names against inclusion regular expressions.<br />Stats whose names do not match any of the configured inclusion patterns are not emitted by the proxy.<br />For more information, see [Envoy Statistics](https://istio.io/latest/docs/ops/configuration/telemetry/envoy-stats/). | Optional <br /> |
 
 ### EgressGateway
 

--- a/internal/controller/istio_controller.go
+++ b/internal/controller/istio_controller.go
@@ -139,6 +139,11 @@ func (r *IstioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return r.terminateReconciliation(ctx, &istioCR, err, operatorv1alpha2.NewReasonWithMessage(operatorv1alpha2.ConditionReasonValidationFailed))
 	}
 
+	err = validation.ValidateProxyStatsMatcher(istioCR)
+	if err != nil {
+		return r.terminateReconciliation(ctx, &istioCR, err, operatorv1alpha2.NewReasonWithMessage(operatorv1alpha2.ConditionReasonValidationFailed))
+	}
+
 	if istioCR.GetNamespace() != namespace {
 		errWrongNS := fmt.Errorf("istio CR is not in %s namespace", namespace)
 		return r.terminateReconciliation(ctx, &istioCR, describederrors.NewDescribedError(errWrongNS, "Stopped Istio CR reconciliation"),

--- a/internal/restarter/predicates/ingressgateway.go
+++ b/internal/restarter/predicates/ingressgateway.go
@@ -2,6 +2,7 @@ package predicates
 
 import (
 	"context"
+	"slices"
 
 	operatorv1alpha2 "github.com/kyma-project/istio/operator/api/v1alpha2"
 	"github.com/kyma-project/istio/operator/internal/reconciliations/istio/configuration"
@@ -21,6 +22,18 @@ func (i RestartPredicate) NewIngressGatewayEvaluator(_ context.Context) (Ingress
 		return nil, err
 	}
 
+	var oldRegexps []string
+	if lastAppliedConfig.Config.ProxyStatsMatcher != nil {
+		oldRegexps = lastAppliedConfig.Config.ProxyStatsMatcher.InclusionRegexps
+	}
+	slices.Sort(oldRegexps)
+
+	var newRegexps []string
+	if i.istioCR.Spec.Config.ProxyStatsMatcher != nil {
+		newRegexps = i.istioCR.Spec.Config.ProxyStatsMatcher.InclusionRegexps
+	}
+	slices.Sort(newRegexps)
+
 	return CompositeIngressGatewayRestartEvaluator{
 		Evaluators: []IngressGatewayRestartEvaluator{
 			NumTrustedProxiesRestartEvaluator{
@@ -34,6 +47,10 @@ func (i RestartPredicate) NewIngressGatewayEvaluator(_ context.Context) (Ingress
 			TrustDomainsRestartEvaluator{
 				NewTrustDomain: i.istioCR.Spec.Config.TrustDomain,
 				OldTrustDomain: lastAppliedConfig.Config.TrustDomain,
+			},
+			ProxyStatsMatcherIngressGatewayRestartEvaluator{
+				NewInclusionRegexps: newRegexps,
+				OldInclusionRegexps: oldRegexps,
 			},
 		},
 	}, nil
@@ -102,4 +119,13 @@ func (i XForwardClientCertRestartEvaluator) RequiresIngressGatewayRestart() bool
 	}
 
 	return false
+}
+
+type ProxyStatsMatcherIngressGatewayRestartEvaluator struct {
+	NewInclusionRegexps []string
+	OldInclusionRegexps []string
+}
+
+func (p ProxyStatsMatcherIngressGatewayRestartEvaluator) RequiresIngressGatewayRestart() bool {
+	return !slices.Equal(p.OldInclusionRegexps, p.NewInclusionRegexps)
 }

--- a/internal/restarter/predicates/ingressgateway.go
+++ b/internal/restarter/predicates/ingressgateway.go
@@ -2,7 +2,6 @@ package predicates
 
 import (
 	"context"
-	"slices"
 
 	operatorv1alpha2 "github.com/kyma-project/istio/operator/api/v1alpha2"
 	"github.com/kyma-project/istio/operator/internal/reconciliations/istio/configuration"
@@ -22,17 +21,10 @@ func (i RestartPredicate) NewIngressGatewayEvaluator(_ context.Context) (Ingress
 		return nil, err
 	}
 
-	var oldRegexps []string
-	if lastAppliedConfig.Config.ProxyStatsMatcher != nil {
-		oldRegexps = lastAppliedConfig.Config.ProxyStatsMatcher.InclusionRegexps
+	proxyStatsMatcher, err := NewProxyStatsMatcherRestartPredicate(i.istioCR)
+	if err != nil {
+		return nil, err
 	}
-	slices.Sort(oldRegexps)
-
-	var newRegexps []string
-	if i.istioCR.Spec.Config.ProxyStatsMatcher != nil {
-		newRegexps = i.istioCR.Spec.Config.ProxyStatsMatcher.InclusionRegexps
-	}
-	slices.Sort(newRegexps)
 
 	return CompositeIngressGatewayRestartEvaluator{
 		Evaluators: []IngressGatewayRestartEvaluator{
@@ -48,10 +40,7 @@ func (i RestartPredicate) NewIngressGatewayEvaluator(_ context.Context) (Ingress
 				NewTrustDomain: i.istioCR.Spec.Config.TrustDomain,
 				OldTrustDomain: lastAppliedConfig.Config.TrustDomain,
 			},
-			ProxyStatsMatcherIngressGatewayRestartEvaluator{
-				NewInclusionRegexps: newRegexps,
-				OldInclusionRegexps: oldRegexps,
-			},
+			proxyStatsMatcher,
 		},
 	}, nil
 }
@@ -119,13 +108,4 @@ func (i XForwardClientCertRestartEvaluator) RequiresIngressGatewayRestart() bool
 	}
 
 	return false
-}
-
-type ProxyStatsMatcherIngressGatewayRestartEvaluator struct {
-	NewInclusionRegexps []string
-	OldInclusionRegexps []string
-}
-
-func (p ProxyStatsMatcherIngressGatewayRestartEvaluator) RequiresIngressGatewayRestart() bool {
-	return !slices.Equal(p.OldInclusionRegexps, p.NewInclusionRegexps)
 }

--- a/internal/restarter/predicates/ingressgateway.go
+++ b/internal/restarter/predicates/ingressgateway.go
@@ -21,11 +21,6 @@ func (i RestartPredicate) NewIngressGatewayEvaluator(_ context.Context) (Ingress
 		return nil, err
 	}
 
-	proxyStatsMatcher, err := NewProxyStatsMatcherRestartPredicate(i.istioCR)
-	if err != nil {
-		return nil, err
-	}
-
 	return CompositeIngressGatewayRestartEvaluator{
 		Evaluators: []IngressGatewayRestartEvaluator{
 			NumTrustedProxiesRestartEvaluator{
@@ -40,7 +35,7 @@ func (i RestartPredicate) NewIngressGatewayEvaluator(_ context.Context) (Ingress
 				NewTrustDomain: i.istioCR.Spec.Config.TrustDomain,
 				OldTrustDomain: lastAppliedConfig.Config.TrustDomain,
 			},
-			proxyStatsMatcher,
+			NewProxyStatsMatcherRestartPredicate(i.istioCR, lastAppliedConfig),
 		},
 	}, nil
 }

--- a/internal/restarter/predicates/ingressgateway_test.go
+++ b/internal/restarter/predicates/ingressgateway_test.go
@@ -263,64 +263,6 @@ var _ = Describe("Ingress Gateway Predicate", func() {
 
 	})
 
-	Context("ProxyStatsMatcherIngressGatewayRestartEvaluator", func() {
-		It("should evaluate to false if inclusionRegexps are the same", func() {
-			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
-				OldInclusionRegexps: []string{".*upstream_rq_retry.*"},
-				NewInclusionRegexps: []string{".*upstream_rq_retry.*"},
-			}
-			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeFalse())
-		})
-
-		It("should evaluate to false if both inclusionRegexps are nil", func() {
-			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
-				OldInclusionRegexps: nil,
-				NewInclusionRegexps: nil,
-			}
-			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeFalse())
-		})
-
-		It("should evaluate to true if inclusionRegexps values differ", func() {
-			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
-				OldInclusionRegexps: []string{".*upstream_rq_retry.*"},
-				NewInclusionRegexps: []string{".*upstream_cx.*"},
-			}
-			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
-		})
-
-		It("should evaluate to true if a regexp is added", func() {
-			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
-				OldInclusionRegexps: []string{".*upstream_rq_retry.*"},
-				NewInclusionRegexps: []string{".*upstream_rq_retry.*", ".*upstream_cx.*"},
-			}
-			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
-		})
-
-		It("should evaluate to true if a regexp is removed", func() {
-			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
-				OldInclusionRegexps: []string{".*upstream_rq_retry.*", ".*upstream_cx.*"},
-				NewInclusionRegexps: []string{".*upstream_rq_retry.*"},
-			}
-			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
-		})
-
-		It("should evaluate to true if old is nil and new is not", func() {
-			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
-				OldInclusionRegexps: nil,
-				NewInclusionRegexps: []string{".*upstream_rq_retry.*"},
-			}
-			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
-		})
-
-		It("should evaluate to true if new is nil and old is not", func() {
-			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
-				OldInclusionRegexps: []string{".*upstream_rq_retry.*"},
-				NewInclusionRegexps: nil,
-			}
-			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
-		})
-	})
-
 	Context("NewIngressGatewayEvaluator proxyStatsMatcher", func() {
 		const (
 			mockIstioTag             string = "1.16.1-distroless"
@@ -345,9 +287,6 @@ var _ = Describe("Ingress Gateway Predicate", func() {
 			evaluator, err := predicate.NewIngressGatewayEvaluator(context.Background())
 
 			Expect(err).NotTo(HaveOccurred())
-			psEvaluator := evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators[3].(predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator)
-			Expect(psEvaluator.OldInclusionRegexps).To(ConsistOf(".*upstream_rq_retry.*"))
-			Expect(psEvaluator.NewInclusionRegexps).To(ConsistOf(".*upstream_cx.*"))
 			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
 		})
 

--- a/internal/restarter/predicates/ingressgateway_test.go
+++ b/internal/restarter/predicates/ingressgateway_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Ingress Gateway Predicate", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(evaluator).NotTo(BeNil())
-			Expect(evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators).To(HaveLen(3))
+			Expect(evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators).To(HaveLen(4))
 			Expect(evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators[0].(predicates.NumTrustedProxiesRestartEvaluator).OldNumTrustedProxies).To(BeNil())
 		})
 
@@ -231,7 +231,7 @@ var _ = Describe("Ingress Gateway Predicate", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(evaluator).NotTo(BeNil())
-			Expect(evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators).To(HaveLen(3))
+			Expect(evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators).To(HaveLen(4))
 			Expect(*evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators[0].(predicates.NumTrustedProxiesRestartEvaluator).NewNumTrustedProxies).To(BeEquivalentTo(1))
 			Expect(*evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators[1].(predicates.XForwardClientCertRestartEvaluator).OldXForwardClientCert).To(BeEquivalentTo(operatorv1alpha2.Sanitize))
 			Expect(*evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators[1].(predicates.XForwardClientCertRestartEvaluator).NewXForwardClientCert).To(BeEquivalentTo(operatorv1alpha2.AppendForward))
@@ -256,10 +256,120 @@ var _ = Describe("Ingress Gateway Predicate", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(evaluator).NotTo(BeNil())
-			Expect(evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators).To(HaveLen(3))
+			Expect(evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators).To(HaveLen(4))
 			Expect(evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators[0].(predicates.NumTrustedProxiesRestartEvaluator).NewNumTrustedProxies).To(BeNil())
 			Expect(evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators[0].(predicates.NumTrustedProxiesRestartEvaluator).OldNumTrustedProxies).To(BeNil())
 		})
 
+	})
+
+	Context("ProxyStatsMatcherIngressGatewayRestartEvaluator", func() {
+		It("should evaluate to false if inclusionRegexps are the same", func() {
+			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
+				OldInclusionRegexps: []string{".*upstream_rq_retry.*"},
+				NewInclusionRegexps: []string{".*upstream_rq_retry.*"},
+			}
+			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeFalse())
+		})
+
+		It("should evaluate to false if both inclusionRegexps are nil", func() {
+			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
+				OldInclusionRegexps: nil,
+				NewInclusionRegexps: nil,
+			}
+			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeFalse())
+		})
+
+		It("should evaluate to true if inclusionRegexps values differ", func() {
+			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
+				OldInclusionRegexps: []string{".*upstream_rq_retry.*"},
+				NewInclusionRegexps: []string{".*upstream_cx.*"},
+			}
+			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
+		})
+
+		It("should evaluate to true if a regexp is added", func() {
+			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
+				OldInclusionRegexps: []string{".*upstream_rq_retry.*"},
+				NewInclusionRegexps: []string{".*upstream_rq_retry.*", ".*upstream_cx.*"},
+			}
+			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
+		})
+
+		It("should evaluate to true if a regexp is removed", func() {
+			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
+				OldInclusionRegexps: []string{".*upstream_rq_retry.*", ".*upstream_cx.*"},
+				NewInclusionRegexps: []string{".*upstream_rq_retry.*"},
+			}
+			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
+		})
+
+		It("should evaluate to true if old is nil and new is not", func() {
+			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
+				OldInclusionRegexps: nil,
+				NewInclusionRegexps: []string{".*upstream_rq_retry.*"},
+			}
+			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
+		})
+
+		It("should evaluate to true if new is nil and old is not", func() {
+			evaluator := predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator{
+				OldInclusionRegexps: []string{".*upstream_rq_retry.*"},
+				NewInclusionRegexps: nil,
+			}
+			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
+		})
+	})
+
+	Context("NewIngressGatewayEvaluator proxyStatsMatcher", func() {
+		const (
+			mockIstioTag             string = "1.16.1-distroless"
+			lastAppliedConfiguration        = labels.LastAppliedConfiguration
+		)
+
+		It("should populate inclusionRegexps from lastAppliedConfiguration and spec", func() {
+			istio := &operatorv1alpha2.Istio{
+				Spec: operatorv1alpha2.IstioSpec{
+					Config: operatorv1alpha2.Config{
+						ProxyStatsMatcher: &operatorv1alpha2.ProxyStatsMatcher{
+							InclusionRegexps: []string{".*upstream_cx.*"},
+						},
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{lastAppliedConfiguration: fmt.Sprintf(`{"config":{"proxyStatsMatcher":{"inclusionRegexps":[".*upstream_rq_retry.*"]}},"IstioTag":"%s"}`, mockIstioTag)},
+				},
+			}
+
+			predicate := predicates.NewIngressGatewayRestartPredicate(istio)
+			evaluator, err := predicate.NewIngressGatewayEvaluator(context.Background())
+
+			Expect(err).NotTo(HaveOccurred())
+			psEvaluator := evaluator.(predicates.CompositeIngressGatewayRestartEvaluator).Evaluators[3].(predicates.ProxyStatsMatcherIngressGatewayRestartEvaluator)
+			Expect(psEvaluator.OldInclusionRegexps).To(ConsistOf(".*upstream_rq_retry.*"))
+			Expect(psEvaluator.NewInclusionRegexps).To(ConsistOf(".*upstream_cx.*"))
+			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeTrue())
+		})
+
+		It("should evaluate to false if inclusionRegexps are the same but in different order", func() {
+			istio := &operatorv1alpha2.Istio{
+				Spec: operatorv1alpha2.IstioSpec{
+					Config: operatorv1alpha2.Config{
+						ProxyStatsMatcher: &operatorv1alpha2.ProxyStatsMatcher{
+							InclusionRegexps: []string{".*upstream_cx.*", ".*upstream_rq_retry.*"},
+						},
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{lastAppliedConfiguration: fmt.Sprintf(`{"config":{"proxyStatsMatcher":{"inclusionRegexps":[".*upstream_rq_retry.*",".*upstream_cx.*"]}},"IstioTag":"%s"}`, mockIstioTag)},
+				},
+			}
+
+			predicate := predicates.NewIngressGatewayRestartPredicate(istio)
+			evaluator, err := predicate.NewIngressGatewayEvaluator(context.Background())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(evaluator.RequiresIngressGatewayRestart()).To(BeFalse())
+		})
 	})
 })

--- a/internal/restarter/predicates/proxy_stats_matcher.go
+++ b/internal/restarter/predicates/proxy_stats_matcher.go
@@ -1,6 +1,7 @@
 package predicates
 
 import (
+	"context"
 	"slices"
 
 	v1 "k8s.io/api/core/v1"
@@ -8,6 +9,7 @@ import (
 	"github.com/kyma-project/istio/operator/api/v1alpha2"
 	"github.com/kyma-project/istio/operator/internal/reconciliations/istio/configuration"
 )
+
 type ProxyStatsMatcherRestartPredicate struct {
 	oldInclusionRegexps []string
 	newInclusionRegexps []string
@@ -47,4 +49,12 @@ func (p ProxyStatsMatcherRestartPredicate) MustMatch() bool {
 
 func (p ProxyStatsMatcherRestartPredicate) Name() string {
 	return "ProxyStatsMatcherRestartPredicate"
+}
+
+func (p ProxyStatsMatcherRestartPredicate) NewIngressGatewayEvaluator(_ context.Context) (IngressGatewayRestartEvaluator, error) {
+	return p, nil
+}
+
+func (p ProxyStatsMatcherRestartPredicate) RequiresIngressGatewayRestart() bool {
+	return !slices.Equal(p.oldInclusionRegexps, p.newInclusionRegexps)
 }

--- a/internal/restarter/predicates/proxy_stats_matcher.go
+++ b/internal/restarter/predicates/proxy_stats_matcher.go
@@ -15,12 +15,7 @@ type ProxyStatsMatcherRestartPredicate struct {
 	newInclusionRegexps []string
 }
 
-func NewProxyStatsMatcherRestartPredicate(istioCR *v1alpha2.Istio) (*ProxyStatsMatcherRestartPredicate, error) {
-	lastAppliedConfig, err := configuration.GetLastAppliedConfiguration(istioCR)
-	if err != nil {
-		return nil, err
-	}
-
+func NewProxyStatsMatcherRestartPredicate(istioCR *v1alpha2.Istio, lastAppliedConfig configuration.AppliedConfig) *ProxyStatsMatcherRestartPredicate {
 	var oldRegexps []string
 	if lastAppliedConfig.Config.ProxyStatsMatcher != nil {
 		oldRegexps = lastAppliedConfig.Config.ProxyStatsMatcher.InclusionRegexps
@@ -36,7 +31,7 @@ func NewProxyStatsMatcherRestartPredicate(istioCR *v1alpha2.Istio) (*ProxyStatsM
 	return &ProxyStatsMatcherRestartPredicate{
 		oldInclusionRegexps: oldRegexps,
 		newInclusionRegexps: newRegexps,
-	}, nil
+	}
 }
 
 func (p ProxyStatsMatcherRestartPredicate) Matches(_ v1.Pod) bool {

--- a/internal/restarter/predicates/proxy_stats_matcher_test.go
+++ b/internal/restarter/predicates/proxy_stats_matcher_test.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1alpha2 "github.com/kyma-project/istio/operator/api/v1alpha2"
+	"github.com/kyma-project/istio/operator/internal/reconciliations/istio/configuration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -75,12 +76,11 @@ var _ = Describe("ProxyStatsMatcher Predicate", func() {
 			}
 			Expect(predicate.Matches(v1.Pod{})).To(BeTrue())
 		})
-
 	})
 
-	Context("NewProxyStatsMatcherRestartPredicate reorder", func() {
+	Context("NewProxyStatsMatcherRestartPredicate", func() {
 		It("should evaluate to false if inclusionRegexps are the same but in different order", func() {
-			predicate, err := NewProxyStatsMatcherRestartPredicate(&operatorv1alpha2.Istio{
+			istioCR := &operatorv1alpha2.Istio{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						labels.LastAppliedConfiguration: `{"config":{"proxyStatsMatcher":{"inclusionRegexps":[".*upstream_rq_retry.*",".*upstream_cx.*"]}}}`,
@@ -93,63 +93,60 @@ var _ = Describe("ProxyStatsMatcher Predicate", func() {
 						},
 					},
 				},
-			})
+			}
+			lastAppliedConfig, err := configuration.GetLastAppliedConfiguration(istioCR)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(predicate.Matches(v1.Pod{})).To(BeFalse())
-		})
-	})
 
-	Context("NewProxyStatsMatcherRestartPredicate", func() {
-		It("should return an error if GetLastAppliedConfiguration fails", func() {
-			_, err := NewProxyStatsMatcherRestartPredicate(&operatorv1alpha2.Istio{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						labels.LastAppliedConfiguration: `{"erroneous-annotation-mock":erroneous-annotation-mock}`,
-					},
-				},
-			})
-			Expect(err).To(HaveOccurred())
+			predicate := NewProxyStatsMatcherRestartPredicate(istioCR, lastAppliedConfig)
+			Expect(predicate.Matches(v1.Pod{})).To(BeFalse())
 		})
 
 		It("should return nil for oldInclusionRegexps if lastAppliedConfiguration is empty", func() {
-			predicate, err := NewProxyStatsMatcherRestartPredicate(&operatorv1alpha2.Istio{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			})
+			istioCR := &operatorv1alpha2.Istio{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			}
+			lastAppliedConfig, err := configuration.GetLastAppliedConfiguration(istioCR)
 			Expect(err).NotTo(HaveOccurred())
+
+			predicate := NewProxyStatsMatcherRestartPredicate(istioCR, lastAppliedConfig)
 			Expect(predicate).NotTo(BeNil())
 			Expect(predicate.oldInclusionRegexps).To(BeNil())
 		})
 
 		It("should return nil for oldInclusionRegexps if proxyStatsMatcher is absent from lastAppliedConfiguration", func() {
-			predicate, err := NewProxyStatsMatcherRestartPredicate(&operatorv1alpha2.Istio{
+			istioCR := &operatorv1alpha2.Istio{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						labels.LastAppliedConfiguration: `{"config":{"enableDNSProxying":true}}`,
 					},
 				},
-			})
+			}
+			lastAppliedConfig, err := configuration.GetLastAppliedConfiguration(istioCR)
 			Expect(err).NotTo(HaveOccurred())
+
+			predicate := NewProxyStatsMatcherRestartPredicate(istioCR, lastAppliedConfig)
 			Expect(predicate).NotTo(BeNil())
 			Expect(predicate.oldInclusionRegexps).To(BeNil())
 		})
 
 		It("should return inclusionRegexps from lastAppliedConfiguration", func() {
-			predicate, err := NewProxyStatsMatcherRestartPredicate(&operatorv1alpha2.Istio{
+			istioCR := &operatorv1alpha2.Istio{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						labels.LastAppliedConfiguration: `{"config":{"proxyStatsMatcher":{"inclusionRegexps":[".*upstream_rq_retry.*",".*upstream_cx.*"]}}}`,
 					},
 				},
-			})
+			}
+			lastAppliedConfig, err := configuration.GetLastAppliedConfiguration(istioCR)
 			Expect(err).NotTo(HaveOccurred())
+
+			predicate := NewProxyStatsMatcherRestartPredicate(istioCR, lastAppliedConfig)
 			Expect(predicate).NotTo(BeNil())
 			Expect(predicate.oldInclusionRegexps).To(ConsistOf(".*upstream_rq_retry.*", ".*upstream_cx.*"))
 		})
 
 		It("should return inclusionRegexps from the Istio CR spec", func() {
-			predicate, err := NewProxyStatsMatcherRestartPredicate(&operatorv1alpha2.Istio{
+			istioCR := &operatorv1alpha2.Istio{
 				Spec: operatorv1alpha2.IstioSpec{
 					Config: operatorv1alpha2.Config{
 						ProxyStatsMatcher: &operatorv1alpha2.ProxyStatsMatcher{
@@ -157,8 +154,11 @@ var _ = Describe("ProxyStatsMatcher Predicate", func() {
 						},
 					},
 				},
-			})
+			}
+			lastAppliedConfig, err := configuration.GetLastAppliedConfiguration(istioCR)
 			Expect(err).NotTo(HaveOccurred())
+
+			predicate := NewProxyStatsMatcherRestartPredicate(istioCR, lastAppliedConfig)
 			Expect(predicate).NotTo(BeNil())
 			Expect(predicate.newInclusionRegexps).To(ConsistOf(".*upstream_rq_retry.*"))
 		})

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
 
 	istioCR "github.com/kyma-project/istio/operator/api/v1alpha2"
 	"github.com/kyma-project/istio/operator/internal/describederrors"
@@ -15,6 +16,18 @@ func ValidateAuthorizers(i istioCR.Istio) describederrors.DescribedError {
 			return describederrors.NewDescribedError(fmt.Errorf("%s is duplicated", authorizer.Name), "Authorizer name needs to be unique").SetWarning()
 		}
 		authorizersNameSet[authorizer.Name] = true
+	}
+	return nil
+}
+
+func ValidateProxyStatsMatcher(i istioCR.Istio) describederrors.DescribedError {
+	if i.Spec.Config.ProxyStatsMatcher == nil {
+		return nil
+	}
+	for _, r := range i.Spec.Config.ProxyStatsMatcher.InclusionRegexps {
+		if _, err := regexp.Compile(r); err != nil {
+			return describederrors.NewDescribedError(fmt.Errorf("%q is not a valid regexp: %w", r, err), "ProxyStatsMatcher inclusionRegexps contains an invalid regular expression")
+		}
 	}
 	return nil
 }

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -85,3 +85,60 @@ var _ = Describe("Validation", func() {
 	})
 
 })
+
+var _ = Describe("ValidateProxyStatsMatcher", func() {
+	It("should successfully validate when proxyStatsMatcher is nil", func() {
+		//given
+		istioCr := istioCR.Istio{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		}
+		//when
+		err := validation.ValidateProxyStatsMatcher(istioCr)
+		//then
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should successfully validate valid regular expressions", func() {
+		//given
+		istioCr := istioCR.Istio{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: istioCR.IstioSpec{
+				Config: istioCR.Config{
+					ProxyStatsMatcher: &istioCR.ProxyStatsMatcher{
+						InclusionRegexps: []string{
+							".*",
+							"cluster\\..*\\.upstream_rq_total",
+							"^http\\..*",
+						},
+					},
+				},
+			},
+		}
+		//when
+		err := validation.ValidateProxyStatsMatcher(istioCr)
+		//then
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fail to validate when an inclusion regexp is invalid", func() {
+		//given
+		istioCr := istioCR.Istio{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: istioCR.IstioSpec{
+				Config: istioCR.Config{
+					ProxyStatsMatcher: &istioCR.ProxyStatsMatcher{
+						InclusionRegexps: []string{
+							"valid.*",
+							"[invalid",
+						},
+					},
+				},
+			},
+		}
+		//when
+		err := validation.ValidateProxyStatsMatcher(istioCr)
+		//then
+		Expect(err).To(HaveOccurred())
+		Expect(err.Description()).To(ContainSubstring("ProxyStatsMatcher inclusionRegexps contains an invalid regular expression"))
+	})
+})

--- a/pkg/lib/sidecars/proxy.go
+++ b/pkg/lib/sidecars/proxy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyma-project/istio/operator/api/v1alpha2"
 	"github.com/kyma-project/istio/operator/internal/images"
 	"github.com/kyma-project/istio/operator/internal/istiofeatures"
+	"github.com/kyma-project/istio/operator/internal/reconciliations/istio/configuration"
 	"github.com/kyma-project/istio/operator/internal/restarter/predicates"
 
 	"github.com/go-logr/logr"
@@ -71,11 +72,12 @@ func (p *ProxyRestart) RestartProxies(
 		p.logger.Error(err, "Failed to create restart enableDNSProxying predicate")
 		return []restart.Warning{}, err
 	}
-	proxyStatsMatcherPredicate, err := predicates.NewProxyStatsMatcherRestartPredicate(istioCR)
+	lastAppliedConfig, err := configuration.GetLastAppliedConfiguration(istioCR)
 	if err != nil {
-		p.logger.Error(err, "Failed to create restart proxyStatsMatcher predicate")
+		p.logger.Error(err, "Failed to get last applied configuration")
 		return []restart.Warning{}, err
 	}
+	proxyStatsMatcherPredicate := predicates.NewProxyStatsMatcherRestartPredicate(istioCR, lastAppliedConfig)
 	istioFeatures, err := istiofeatures.Get(ctx, p.k8sClient)
 	if err != nil && !apierrors.IsNotFound(err) {
 		p.logger.Error(err, "Failed to get Istio features")


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add predicate to istio-ingressgateway restarter for proxy stats matcher changes
- Add validation for proxy stats matcher to ensure the regexp is correct
- Extend docs with link to the upstream docs

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.
- [x] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [x] RBAC settings are as restrictive as possible.
- [x] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [x] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.
- [x] You checked if Busola updates are needed.
- [x] If you added a predicate for restarters, check if the **lastAppliedConfiguration** annotation is properly updated after the given restart is executed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
